### PR TITLE
feat: Add Dead Letter Queue for SQS

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -142,7 +142,25 @@ Resources:
   BuildQueue:
     Type: AWS::SQS::Queue
     Properties:
-      VisibilityTimeout: 301
+      VisibilityTimeout:
+        Ref: SQSVisibilityTimeout
+      RedrivePolicy:
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - "BuildDLQ"
+            - "Arn"
+        maxReceiveCount: 5
+
+  BuildDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout:
+        Ref: SQSVisibilityTimeout
+
+Parameters:
+  SQSVisibilityTimeout:
+    Type: Number
+    Default: 301
 
 Outputs:
   ApiEndpoint:


### PR DESCRIPTION
Add a second queue to the SAM template and adds a parameter for the visibility
timeout. This allows setting a lower value than the 5 minutes used in production,
which makes it easier to test locally.

For the maxReceiveCount setting, 5 was chosen as it makes for a sensible default
value.

Closes #60

---

I left the queue parameters with their default values, so _if_ messages do get in the DQL, they'll stay there for at most 4 days. I'm also not adding anything to process the messages from the DQL, as mentioned in the issue there isn't an issue with failing builds right now so its not a top priority. At the very least I think we could add a cloudwatch alarm when there are messages older than say a day in the DQL, but I didn't want to go too far with this PR.

I really wanted to find a way to include an integration test for this change, but because the test suite is using softwaremill/elasticmq and not SQS, I'm not sure it can even replicate the DQL behavior of SQS. I did do some testing manually on my own AWS and it works as exected!