### PR TITLE
fix: moderation bucket permissions

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -33,6 +33,8 @@ Resources:
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref StorageBucket
+        - S3CrudPolicy:
+            BucketName: !Ref ModerationBucket
         - SQSSendMessagePolicy:
             QueueName: !GetAtt BuildQueue.QueueName
       Environment:


### PR DESCRIPTION
Recent moderation filter PR broke version uploads because of a missing permission for all uploaded modules. This fixes this. Fixes #83 