### PR TITLE
fix: silent error when database connection fails (#74)

### DIFF
--- a/api/modules/list.ts
+++ b/api/modules/list.ts
@@ -21,8 +21,6 @@ export async function handler(
   event: APIGatewayProxyEventV2,
   context: Context,
 ): Promise<APIGatewayProxyResultV2> {
-  // TODO(lucacasonato): gracefully handle errors
-
   const limit = parseInt(event.queryStringParameters?.limit || "20");
   const page = parseInt(event.queryStringParameters?.page || "1");
   const query = event.queryStringParameters?.query || undefined;

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -51,6 +51,9 @@ export class Database {
 
   constructor(mongoUri: string) {
     this.mongo.connectWithUri(mongoUri);
+    if (this.mongo.clientId === null || this.mongo.clientId === undefined) {
+      throw new Error("Could not connect to database.");
+    }
   }
 
   async getModule(name: string): Promise<Module | null> {


### PR DESCRIPTION
Adds visibility in the Lambda logs when connection to mongodb fails, Fixes #74 

Note, this is a big ol' patch of duct tape to give a little more visibility that there's an issue with the database connection. Ultimately, the issue comes from the underlying mongodb library that just assigns undefined to the clientId instead of raising an error. A long term fix would require either submitting a change to the mongo lib, or use a different one