### PR TITLE
chore: add cloudwatch alarms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,13 @@ jobs:
       - name: Create terraform plan (prod)
         if: github.ref == 'refs/heads/main'
         run: |
-          terraform init -backend-config bucket=$TERRAFORM_STATE_BUCKET
+          terraform init -backend-config bucket=$TERRAFORM_STATE_BUCKET -backend-config "region=$AWS_DEFAULT_REGION"
           terraform plan \
             -var env=prod \
             -var mongodb_uri=$MONGODB_URI \
             -var domain=$DOMAIN \
             -var certificate_arn=$CERTIFICATE_ARN \
+            -var region=$AWS_DEFAULT_REGION \
             -out plan.tfplan
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}

--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -1,0 +1,67 @@
+resource "aws_sns_topic" "alarm" {
+  name = "${local.prefix}-alarms-${local.short_uuid}"
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  for_each = {
+    publish = aws_lambda_function.async_publish.function_name,
+    webhook = aws_lambda_function.webhook_github.function_name,
+    get     = aws_lambda_function.modules_get.function_name,
+    list    = aws_lambda_function.modules_list.function_name,
+    builds  = aws_lambda_function.builds_get.function_name,
+  }
+
+  alarm_name          = "${local.prefix}-lambda-errors-alarm-${each.key}-${local.short_uuid}"
+  alarm_description   = "Lambda function failed more than 10 times in the last 5 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  datapoints_to_alarm = 1
+  statistic           = "Sum"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  dimensions = {
+    "FunctionName" = each.value
+  }
+  threshold          = 10
+  treat_missing_data = "missing"
+  alarm_actions      = [aws_sns_topic.alarm.arn]
+  tags               = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "stuck_builds" {
+  alarm_name          = "${local.prefix}-build-queue-old-messages-${local.short_uuid}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  datapoints_to_alarm = 1
+  statistic           = "Maximum"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  dimensions = {
+    "QueueName" = aws_sqs_queue.build_queue.name
+  }
+  threshold          = 900 // 15 minutes
+  treat_missing_data = "missing"
+  alarm_actions      = [aws_sns_topic.alarm.arn]
+  tags               = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "dlq_messages" {
+  alarm_name          = "${local.prefix}-total-build-dlq-${local.short_uuid}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  datapoints_to_alarm = 1
+  statistic           = "Average"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  dimensions = {
+    "QueueName" = aws_sqs_queue.build_dlq.name
+  }
+  threshold          = 25
+  treat_missing_data = "missing"
+  alarm_actions      = [aws_sns_topic.alarm.arn]
+  tags               = local.tags
+}

--- a/terraform/meta.tf
+++ b/terraform/meta.tf
@@ -9,8 +9,7 @@ terraform {
     }
   }
   backend "s3" {
-    key    = "terraform.tfstate"
-    region = "us-east-1"
+    key = "terraform.tfstate"
   }
 }
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
 }

--- a/terraform/publish.tf
+++ b/terraform/publish.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "async_publish" {
   source_code_hash = filebase64sha256(data.archive_file.async_publish_zip.output_path)
 
   runtime = "provided"
-  layers  = [aws_lambda_layer_version.deno_layer.arn, "arn:aws:lambda:us-east-1:553035198032:layer:git-lambda2:6"]
+  layers  = [aws_lambda_layer_version.deno_layer.arn, "arn:aws:lambda:${var.region}:553035198032:layer:git-lambda2:6"]
 
   timeout     = 300
   memory_size = 1024

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,4 +1,5 @@
 env             = "staging"
+region          = "us-east-1"
 mongodb_uri     = "mongodb+srv://<user>:<password>@<cluster>.<id>.mongodb.net/?retryWrites=true&w=majority"
 domain          = "api.myregistry.com"
 certificate_arn = "arn:aws:acm:<region>:<id>:certificate/<certificate_id>"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "the AWS region"
+  type        = string
+}
+
 variable "mongodb_uri" {
   description = "MongoDB conection string"
   type        = string


### PR DESCRIPTION
* add an alarm for total execution errors over 10 minutes for each
  lambda function
* add an alarm for old messages in the build queue
* add an alarm for total visible messages in the dead letter queue
* parameterized the aws region

Make sure to create at least one topic subscription after rolling out these changes to get notified by alerts.

Fixes #75