### PR TITLE
fix: add listbucket iam permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.deno_plugins

--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -29,9 +29,9 @@ resource "aws_cloudwatch_metric_alarm" "publish_lambda_errors" {
 
 resource "aws_cloudwatch_metric_alarm" "data_lambda_errors" {
   for_each = {
-    get     = aws_lambda_function.modules_get.function_name,
-    list    = aws_lambda_function.modules_list.function_name,
-    builds  = aws_lambda_function.builds_get.function_name,
+    get    = aws_lambda_function.modules_get.function_name,
+    list   = aws_lambda_function.modules_list.function_name,
+    builds = aws_lambda_function.builds_get.function_name,
   }
 
   alarm_name          = "${local.prefix}-lambda-errors-alarm-${each.key}-${local.short_uuid}"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "lambda_permissions" {
       "s3:GetObject",
       "s3:PutObject",
       "s3:PutObjectAcl",
+      "s3:ListBucket",
     ]
     resources = [
       aws_s3_bucket.storage_bucket.arn,


### PR DESCRIPTION
New module uploads are failing because of this right now. Also increased sensitivity on cloudwatch alerts to catch this error.

This is needed because s3::GetObject returns 403 on not found if ListBuckets permission is not present.