### PR TITLE
ops: add replication configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-east-1
+      AWS_BACKUP_REGION: eu-central-1
       CLOUDFLARE_ACCOUNT_ID: 895762025d37fc687ecd72d7cc80204a
       CLOUDFLARE_ZONE_ID: c192cf8ac042c681023493c52edd44c8
     steps:
@@ -55,6 +56,7 @@ jobs:
             -var cdn_domain=$CDN_DOMAIN \
             -var certificate_arn=$CERTIFICATE_ARN \
             -var region=$AWS_DEFAULT_REGION \
+            -var backup_region=$AWS_BACKUP_REGION \
             -var cloudflare_account_id=$CLOUDFLARE_ACCOUNT_ID \
             -var cloudflare_zone_id=$CLOUDFLARE_ZONE_ID \
             -out plan.tfplan

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -5,3 +5,8 @@ provider "aws" {
 provider "cloudflare" {
   account_id = var.cloudflare_account_id
 }
+
+provider "aws" {
+  alias  = "backup"
+  region = var.backup_region
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,5 +1,6 @@
 env                   = "staging"
 region                = "us-east-1"
+backup_region         = "eu-central-1"
 mongodb_uri           = "mongodb+srv://<user>:<password>@<cluster>.<id>.mongodb.net/?retryWrites=true&w=majority"
 api_domain            = "api.myregistry.com"
 cdn_domain            = "cdn.myregistry.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   type        = string
 }
 
+variable "backup_region" {
+  description = "the AWS region used for backups"
+  type        = string
+}
+
 variable "mongodb_uri" {
   description = "MongoDB conection string"
   type        = string


### PR DESCRIPTION
Add a replication configuration to keep a backup of modules in a different (parameterized) AWS region. A lifecycle policy has been set on the backup bucket so that objects transition to standard infrequent access over time to save on storage costs.

Fixes #90