### PR TITLE
ops: add publish option to lambda functions

### DIFF
--- a/terraform/builds.tf
+++ b/terraform/builds.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "builds_get" {
   function_name = "${local.prefix}_builds_get_${local.short_uuid}"
   role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
+  publish       = true
 
   source_code_hash = filebase64sha256(data.archive_file.builds_get_zip.output_path)
 

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_function" "modules_get" {
   function_name = "${local.prefix}_modules_get_${local.short_uuid}"
   role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
+  publish       = true
 
   source_code_hash = filebase64sha256(data.archive_file.modules_get_zip.output_path)
 
@@ -66,6 +67,7 @@ resource "aws_lambda_function" "modules_list" {
   function_name = "${local.prefix}_modules_list_${local.short_uuid}"
   role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
+  publish       = true
 
   source_code_hash = filebase64sha256(data.archive_file.modules_list_zip.output_path)
 

--- a/terraform/publish.tf
+++ b/terraform/publish.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "async_publish" {
   function_name = "${local.prefix}_async_publish_${local.short_uuid}"
   role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
+  publish       = true
 
   source_code_hash = filebase64sha256(data.archive_file.async_publish_zip.output_path)
 

--- a/terraform/webhook.tf
+++ b/terraform/webhook.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "webhook_github" {
   function_name = "${local.prefix}_webhook_github_${local.short_uuid}"
   role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
+  publish       = true
 
   source_code_hash = filebase64sha256(data.archive_file.webhook_github_zip.output_path)
 


### PR DESCRIPTION
This was one of the reasons to switch to Terraform: easily enable Lambda
versioning using the `publish` option.