### PR TITLE
fix: get deno info output before getting status

### DIFF
--- a/utils/deno.ts
+++ b/utils/deno.ts
@@ -20,8 +20,8 @@ export async function runDenoInfo(
     stdout: "piped",
     stderr: "inherit",
   });
-  const status = await p.status();
   const file = await p.output();
+  const status = await p.status();
   p.close();
   if (!status.success) {
     throw new Error(`Failed to run deno info for ${options.entrypoint}`);


### PR DESCRIPTION
Fixes #119.

I tested this locally. Is there an upstream Deno bug for this behaviour? I don't think it should just hang if you do `output` before `status`...