### PR TITLE
Meilisearch deployment on Fargate

### DIFF
--- a/terraform/search.tf
+++ b/terraform/search.tf
@@ -1,0 +1,82 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "public" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+# TODO(wperron): ecs service goes here, depends on ALB, which depends on SG
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${local.prefix}-meili-task-def-${local.short_uuid}"
+  container_definitions    = file("${path.module}/task_definitions/search.json")
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  tags                     = local.tags
+
+  volume {
+    name = "data"
+    efs_volume_configuration {
+      file_system_id = aws_efs_file_system.this.id
+      root_directory = "/opt/data"
+    }
+  }
+}
+
+resource "aws_lb" "this" {
+  name               = "load-balancer-${local.short_uuid}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.this.id]
+  subnets            = data.aws_subnet_ids.public.ids
+  tags               = local.tags
+}
+
+resource "aws_lb_target_group" "this" {
+  name     = "search-${local.short_uuid}"
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = data.aws_vpc.default.id
+}
+
+resource "aws_security_group" "this" {
+  name        = "${local.prefix}-public-tls-sg-${local.short_uuid}"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "TLS from Internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+resource "aws_efs_file_system" "this" {
+  creation_token = local.short_uuid
+  tags           = local.tags
+}
+
+resource "aws_ecs_cluster" "this" {
+  name               = "${local.prefix}-ecs-cluster-${local.short_uuid}"
+  capacity_providers = ["FARGATE"]
+  tags               = local.tags
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}

--- a/terraform/search.tf
+++ b/terraform/search.tf
@@ -21,7 +21,9 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    subnets = data.aws_subnet_ids.public.ids
+    subnets          = data.aws_subnet_ids.public.ids
+    security_groups  = [aws_security_group.this.id]
+    assign_public_ip = true
   }
 }
 

--- a/terraform/task_definitions/search.json
+++ b/terraform/task_definitions/search.json
@@ -3,7 +3,7 @@
     "name": "meilisearch",
     "image": "getmeili/meilisearch:v0.14.0",
     "cpu": 512,
-    "memory": 2014,
+    "memory": 1024,
     "essential": true,
     "portMappings": [
       {

--- a/terraform/task_definitions/search.json
+++ b/terraform/task_definitions/search.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "meilisearch",
+    "image": "getmeili/meilisearch:v0.14.0",
+    "cpu": 256,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 7700,
+        "hostPort": 7700
+      }
+    ],
+    "mountPoints": [
+      {
+        "containerPath": "/data.ms",
+        "sourceVolume": "data"
+      }
+    ]
+  }
+]

--- a/terraform/task_definitions/search.json
+++ b/terraform/task_definitions/search.json
@@ -2,8 +2,8 @@
   {
     "name": "meilisearch",
     "image": "getmeili/meilisearch:v0.14.0",
-    "cpu": 256,
-    "memory": 512,
+    "cpu": 512,
+    "memory": 2014,
     "essential": true,
     "portMappings": [
       {
@@ -11,6 +11,14 @@
         "hostPort": 7700
       }
     ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "meilisearch"
+      }
+    },
     "mountPoints": [
       {
         "containerPath": "/data.ms",


### PR DESCRIPTION
This PR introduces the necessary AWS resources to deploy Meilisearch on Fargate. I personally like Fargate because while the straight compute-hour cost is higher that EC2, it removes a lot of complexity from the management side of things; logging and metrics monitoring is baked-in with Container Insights, the ECS service takes care of restarting failed instances automatically without needing an Autoscaling Group, using a Docker image means we don't have to deal with managing server configurations or ssh into a server. I'm not religiously attached to Fargate, we can discuss the pros/cons and I always move to a more traditional EC2 deployment if need be.

Here's a rough price estimate:

- [Fargate](https://aws.amazon.com/fargate/pricing/): $21.62 with a single instance at 0.5vcpu, 2Gb memory
- [EFS](https://aws.amazon.com/efs/pricing/): < $0.30 (less than 1Gb total)
- [ALB](https://aws.amazon.com/elasticloadbalancing/pricing/): $16.74/mo flat rate + LCU-hours depending on _new http connections_ per hour

Note that the Load Balancer isn't stricly necessary, we could also use a simple dns-based round-robin and get the job done just fine; ALB simply makes it easier to integrate with Security Groups and AWS Certificate Manager.

Checklist:
- [x] perform some tests to make sure the EFS volume mount works as expected
- [x] perform some tests with more than one instance (load & resiliency)
- [ ] perform tests with meili version upgrades
- [ ] configure Meilisearch master key to control access
- [ ] tweak LB to only allow external traffic to the `/search` endpoint
- [ ] adjust resource allocation based on the amount of data we estimate we'll need
- [X] get some metrics on the current usage of the search endpoint to estimate the LB costs
- [ ] Implement a backup strategy

Fixes #69 