### PR TITLE
feat: add total number of modules to stat endpoint

### DIFF
--- a/api/stats.ts
+++ b/api/stats.ts
@@ -19,8 +19,9 @@ export async function handler(
   event: APIGatewayProxyEventV2,
   context: Context,
 ): Promise<APIGatewayProxyResultV2> {
-  const recentlyAddedModules = await database.listRecentlyAddedModules();
-  const recentlyUploadedVersions = await database
+  const total_count = await database.countModules();
+  const recently_added_modules = await database.listRecentlyAddedModules();
+  const recently_uploaded_versions = await database
     .listRecentlyUploadedVersions();
 
   return respondJSON({
@@ -28,8 +29,9 @@ export async function handler(
     body: JSON.stringify({
       success: true,
       data: {
-        recentlyAddedModules,
-        recentlyUploadedVersions,
+        total_count,
+        recently_added_modules,
+        recently_uploaded_versions,
       },
     }),
   });

--- a/api/stats_test.ts
+++ b/api/stats_test.ts
@@ -119,7 +119,7 @@ Deno.test({
       res,
       {
         body:
-          '{"success":true,"data":{"recentlyAddedModules":[{"name":"ltest1","description":"ltest1 repo","star_count":50,"created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest3","description":"ltest3 repo","star_count":50,"created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest2","description":"ltest2 repo","star_count":50,"created_at":"2020-02-01T00:00:00.000Z"}],"recentlyUploadedVersions":[{"name":"ltest","version":"0.2.0","created_at":"2020-02-04T00:00:00.000Z"},{"name":"ltest3","version":"0.3.0","created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest2","version":"0.1.0","created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest","version":"0.1.0","created_at":"2020-02-01T00:00:00.000Z"}]}}',
+          '{"success":true,"data":{"total_count":3,"recently_added_modules":[{"name":"ltest1","description":"ltest1 repo","star_count":50,"created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest3","description":"ltest3 repo","star_count":50,"created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest2","description":"ltest2 repo","star_count":50,"created_at":"2020-02-01T00:00:00.000Z"}],"recently_uploaded_versions":[{"name":"ltest","version":"0.2.0","created_at":"2020-02-04T00:00:00.000Z"},{"name":"ltest3","version":"0.3.0","created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest2","version":"0.1.0","created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest","version":"0.1.0","created_at":"2020-02-01T00:00:00.000Z"}]}}',
         headers: {
           "content-type": "application/json",
         },


### PR DESCRIPTION
Felt like this might be a useful info for the `/stats/` endpoint. I used the `total_count` because that's what's used in the modules list endpoint, but it clashes with the other keys of this endpoint so I'm not sure about that.