### PR TITLE
fix: set content security policy

### DIFF
--- a/api/worker.js
+++ b/api/worker.js
@@ -11,6 +11,10 @@ async function handleRequest(request) {
   });
   const resp2 = new Response(resp.body, resp);
   resp2.headers.set("Access-Control-Allow-Origin", "*");
+  resp2.headers.set(
+    "Content-Security-Policy",
+    "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+  );
   return resp2;
 }
 


### PR DESCRIPTION
This sets a strict `Content-Security-Policy` for all resources returned from `cdn.deno.land`.