### PR TITLE
refactor: add deps_v2.json that includes size

### DIFF
--- a/api/async/publish.ts
+++ b/api/async/publish.ts
@@ -188,6 +188,7 @@ async function publishGithub(
           ref,
         },
       },
+      true,
     );
 
     return {
@@ -204,7 +205,8 @@ async function publishGithub(
 interface DependencyGraph {
   nodes: {
     [url: string]: {
-      imports: string[];
+      size: number;
+      deps: string[];
     };
   };
 }
@@ -260,19 +262,20 @@ async function analyzeDependencies(build: Build): Promise<void> {
   await uploadVersionMetaJson(
     build.options.moduleName,
     build.options.version,
-    "deps.json",
+    "deps_v2.json",
     { graph },
+    false,
   );
 }
 
 function treeToGraph(graph: DependencyGraph, dep: Dep) {
   const url = dep.name;
   if (!graph.nodes[url]) {
-    graph.nodes[url] = { imports: [] };
+    graph.nodes[url] = { deps: [], size: dep.size };
   }
   dep.deps.forEach((dep) => {
-    if (!graph.nodes[url].imports.includes(dep.name)) {
-      graph.nodes[url].imports.push(dep.name);
+    if (!graph.nodes[url].deps.includes(dep.name)) {
+      graph.nodes[url].deps.push(dep.name);
     }
   });
   dep.deps.forEach((dep) => treeToGraph(graph, dep));

--- a/api/async/publish_test.ts
+++ b/api/async/publish_test.ts
@@ -169,7 +169,7 @@ Deno.test({
     );
 
     let deps = await s3.getObject("ltest/versions/0.0.9/meta/deps_v2.json");
-    assertEquals(deps?.cacheControl, "public, max-age=31536000, immutable");
+    assertEquals(deps?.cacheControl, "max-age=10, must-revalidate");
     assertEquals(deps?.contentType, "application/json");
     // Check that meta file exists
     assertEquals(
@@ -182,97 +182,106 @@ Deno.test({
         graph: {
           nodes: {
             "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/deps.ts": {
-              "imports": [
-                "https://deno.land/std@0.64.0/uuid/mod.ts",
-              ],
+              deps: ["https://deno.land/std@0.64.0/uuid/mod.ts"],
+              size: 63,
             },
             "https://deno.land/std@0.64.0/uuid/mod.ts": {
-              "imports": [
+              deps: [
                 "https://deno.land/std@0.64.0/uuid/v1.ts",
                 "https://deno.land/std@0.64.0/uuid/v4.ts",
                 "https://deno.land/std@0.64.0/uuid/v5.ts",
               ],
+              size: 601,
             },
             "https://deno.land/std@0.64.0/uuid/v1.ts": {
-              "imports": [
-                "https://deno.land/std@0.64.0/uuid/_common.ts",
-              ],
+              deps: ["https://deno.land/std@0.64.0/uuid/_common.ts"],
+              size: 2545,
             },
             "https://deno.land/std@0.64.0/uuid/_common.ts": {
-              "imports": [],
+              deps: [],
+              size: 1207,
             },
             "https://deno.land/std@0.64.0/uuid/v4.ts": {
-              "imports": [
-                "https://deno.land/std@0.64.0/uuid/_common.ts",
-              ],
+              deps: ["https://deno.land/std@0.64.0/uuid/_common.ts"],
+              size: 542,
             },
             "https://deno.land/std@0.64.0/uuid/v5.ts": {
-              "imports": [
+              deps: [
                 "https://deno.land/std@0.64.0/uuid/_common.ts",
                 "https://deno.land/std@0.64.0/hash/sha1.ts",
                 "https://deno.land/std@0.64.0/node/util.ts",
                 "https://deno.land/std@0.64.0/_util/assert.ts",
               ],
+              size: 1340,
             },
             "https://deno.land/std@0.64.0/hash/sha1.ts": {
-              "imports": [],
+              deps: [],
+              size: 11033,
             },
             "https://deno.land/std@0.64.0/node/util.ts": {
-              "imports": [
+              deps: [
                 "https://deno.land/std@0.64.0/node/_util/_util_promisify.ts",
                 "https://deno.land/std@0.64.0/node/_util/_util_callbackify.ts",
                 "https://deno.land/std@0.64.0/node/_util/_util_types.ts",
                 "https://deno.land/std@0.64.0/node/_utils.ts",
               ],
+              size: 2298,
             },
             "https://deno.land/std@0.64.0/node/_util/_util_promisify.ts": {
-              "imports": [],
+              deps: [],
+              size: 4839,
             },
             "https://deno.land/std@0.64.0/node/_util/_util_callbackify.ts": {
-              "imports": [],
+              deps: [],
+              size: 4287,
             },
             "https://deno.land/std@0.64.0/node/_util/_util_types.ts": {
-              "imports": [],
+              deps: [],
+              size: 7362,
             },
             "https://deno.land/std@0.64.0/node/_utils.ts": {
-              "imports": [],
+              deps: [],
+              size: 3807,
             },
             "https://deno.land/std@0.64.0/_util/assert.ts": {
-              "imports": [],
+              deps: [],
+              size: 405,
             },
             "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/example.ts":
               {
-                "imports": [
+                deps: [
                   "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod.ts",
                 ],
+                size: 50,
               },
             "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod.ts": {
-              "imports": [
+              deps: [
                 "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/deps.ts",
               ],
+              size: 139,
             },
             "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod_test.ts":
               {
-                "imports": [
-                  "https://deno.land/std@0.64.0/testing/asserts.ts",
-                ],
+                deps: ["https://deno.land/std@0.64.0/testing/asserts.ts"],
+                size: 227,
               },
             "https://deno.land/std@0.64.0/testing/asserts.ts": {
-              "imports": [
+              deps: [
                 "https://deno.land/std@0.64.0/fmt/colors.ts",
                 "https://deno.land/std@0.64.0/testing/diff.ts",
               ],
+              size: 12246,
             },
             "https://deno.land/std@0.64.0/fmt/colors.ts": {
-              "imports": [],
+              deps: [],
+              size: 5774,
             },
             "https://deno.land/std@0.64.0/testing/diff.ts": {
-              "imports": [],
+              deps: [],
+              size: 5473,
             },
             "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/subproject/mod.ts":
-              {
-                "imports": [],
-              },
+              { deps: [], size: 71 },
           },
         },
       },

--- a/api/async/publish_test.ts
+++ b/api/async/publish_test.ts
@@ -168,7 +168,7 @@ Deno.test({
       },
     );
 
-    let deps = await s3.getObject("ltest/versions/0.0.9/meta/deps.json");
+    let deps = await s3.getObject("ltest/versions/0.0.9/meta/deps_v2.json");
     assertEquals(deps?.cacheControl, "public, max-age=31536000, immutable");
     assertEquals(deps?.contentType, "application/json");
     // Check that meta file exists
@@ -304,7 +304,7 @@ Deno.test({
     await database._builds.deleteMany({});
     await s3.deleteObject("ltest/meta/versions.json");
     await s3.deleteObject("ltest/versions/0.0.9/meta/meta.json");
-    await s3.deleteObject("ltest/versions/0.0.9/meta/deps.json");
+    await s3.deleteObject("ltest/versions/0.0.9/meta/deps_v2.json");
     await s3.deleteObject("ltest/versions/0.0.9/raw/.github/workflows/ci.yml");
     await s3.deleteObject("ltest/versions/0.0.9/raw/.vscode/settings.json");
     await s3.deleteObject("ltest/versions/0.0.9/raw/LICENCE");

--- a/api/stats_test.ts
+++ b/api/stats_test.ts
@@ -112,9 +112,6 @@ Deno.test({
       createContext(),
     );
 
-    // @ts-ignore asd
-    console.log(res.body);
-
     assertEquals(
       res,
       {

--- a/utils/deno.ts
+++ b/utils/deno.ts
@@ -2,7 +2,7 @@ const decoder = new TextDecoder();
 
 export interface Dep {
   name: string;
-  size: string;
+  size: number;
   deps: Dep[];
 }
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -101,14 +101,17 @@ export async function uploadVersionMetaJson(
   version: string,
   file: string,
   data: unknown,
+  immutable: boolean,
 ): Promise<{ etag: string }> {
   const resp = await s3.putObject(
     join(module, "versions", version, "meta", file),
     encoder.encode(JSON.stringify(data)),
     {
       acl: "public-read",
-      // Versioned files can be cached indefinitely. (1 year)
-      cacheControl: "public, max-age=31536000, immutable",
+      // Immutable files can be cached indefinitely. (1 year)
+      cacheControl: immutable
+        ? "public, max-age=31536000, immutable"
+        : "max-age=10, must-revalidate",
       contentType: "application/json",
     },
   );


### PR DESCRIPTION
I had to create a new file revision for this, because the old `deps.json` has very very long cache headers.