### PR TITLE
feat: add short param for GET /modules

### DIFF
--- a/api/modules/list.ts
+++ b/api/modules/list.ts
@@ -4,7 +4,7 @@
  * This function is responsible for listing the modules stored in the
  * database. It can be filtered with a search query and is paginated.
  * The function is triggered by a HTTP GET call to /modules. More
- * information in API.md. 
+ * information in API.md.
  */
 
 import type {
@@ -21,6 +21,15 @@ export async function handler(
   event: APIGatewayProxyEventV2,
   context: Context,
 ): Promise<APIGatewayProxyResultV2> {
+  const simple = event.queryStringParameters?.simple === "1";
+  if (simple) {
+    const results = await database.listAllModuleNames();
+    return respondJSON({
+      statusCode: 200,
+      body: JSON.stringify(results),
+    });
+  }
+
   const limit = parseInt(event.queryStringParameters?.limit || "20");
   const page = parseInt(event.queryStringParameters?.page || "1");
   const query = event.queryStringParameters?.query || undefined;

--- a/api/modules/list_test.ts
+++ b/api/modules/list_test.ts
@@ -43,6 +43,24 @@ Deno.test({
 
     assertEquals(
       await handler(
+        createAPIGatewayProxyEventV2("GET", "/modules?simple=1", {
+          queryStringParameters: {
+            simple: "1",
+          },
+        }),
+        createContext(),
+      ),
+      {
+        body: '["ltest0","ltest1","ltest2","ltest3","ltest4"]',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      },
+    );
+
+    assertEquals(
+      await handler(
         createAPIGatewayProxyEventV2("GET", "/modules", {
           queryStringParameters: {
             page: "2",

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -202,6 +202,22 @@ export class Database {
     }));
   }
 
+  async listAllModuleNames(): Promise<string[]> {
+    const results = await this._modules.aggregate([
+      {
+        $match: {
+          is_unlisted: { $not: { $eq: true } },
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+        },
+      },
+    ]) as { _id: string }[];
+    return results.map((o) => o._id);
+  }
+
   async countModules(): Promise<number> {
     return this._modules.count({
       is_unlisted: { $not: { $eq: true } },


### PR DESCRIPTION
This will be used for the generic version of import IntelliSense in the VS Code extension.