### PR TITLE
chore: avoid cascading failures in tests

### DIFF
--- a/api/async/publish_test.ts
+++ b/api/async/publish_test.ts
@@ -1,5 +1,6 @@
 import { handler } from "./publish.ts";
 import {
+  cleanupDatabase,
   createContext,
   createSQSEvent,
 } from "../../utils/test_utils.ts";
@@ -14,425 +15,430 @@ const decoder = new TextDecoder();
 Deno.test({
   name: "publish success",
   async fn() {
-    const id = await database.createBuild({
-      options: {
-        moduleName: "ltest",
-        ref: "0.0.9",
-        repository: "luca-rand/testing",
-        type: "github",
-        version: "0.0.9",
-      },
-      status: "queued",
-    });
-
-    await handler(
-      createSQSEvent({ buildID: id }),
-      createContext(),
-    );
-
-    assertEquals({ ...await database.getBuild(id), created_at: undefined }, {
-      created_at: undefined,
-      id,
-      options: {
-        moduleName: "ltest",
-        ref: "0.0.9",
-        repository: "luca-rand/testing",
-        type: "github",
-        version: "0.0.9",
-      },
-      status: "success",
-      message: "Published module.",
-      stats: {
-        skipped_due_to_size: [],
-        total_files: 11,
-        total_size: 2735,
-      },
-    });
-
-    // Check that versions.json file exists
-    let versions = await s3.getObject("ltest/meta/versions.json");
-    assertEquals(versions?.cacheControl, "max-age=10, must-revalidate");
-    assertEquals(versions?.contentType, "application/json");
-    assertEquals(
-      JSON.parse(decoder.decode(versions?.body)),
-      { latest: "0.0.9", versions: ["0.0.9"] },
-    );
-
-    let meta = await s3.getObject("ltest/versions/0.0.9/meta/meta.json");
-    assertEquals(meta?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(meta?.contentType, "application/json");
-    // Check that meta file exists
-    assertEquals(
-      {
-        ...JSON.parse(
-          decoder.decode(
-            meta?.body,
-          ),
-        ),
-        uploaded_at: undefined,
-      },
-      {
-        directory_listing: [
-          {
-            path: "",
-            size: 2735,
-            type: "dir",
-          },
-          {
-            path: "/.github",
-            size: 716,
-            type: "dir",
-          },
-          {
-            path: "/.github/README.md",
-            size: 304,
-            type: "file",
-          },
-          {
-            path: "/.github/workflows",
-            size: 412,
-            type: "dir",
-          },
-          {
-            path: "/.github/workflows/ci.yml",
-            size: 412,
-            type: "file",
-          },
-          {
-            path: "/.vscode",
-            size: 26,
-            type: "dir",
-          },
-          {
-            path: "/.vscode/settings.json",
-            size: 26,
-            type: "file",
-          },
-          {
-            path: "/LICENSE",
-            size: 1066,
-            type: "file",
-          },
-          {
-            path: "/deps.ts",
-            size: 63,
-            type: "file",
-          },
-          {
-            path: "/example.ts",
-            size: 50,
-            type: "file",
-          },
-          {
-            path: "/fixtures",
-            size: 23,
-            type: "dir",
-          },
-          {
-            path: "/fixtures/%",
-            size: 23,
-            type: "file",
-          },
-          {
-            path: "/mod.ts",
-            size: 139,
-            type: "file",
-          },
-          {
-            path: "/mod_test.ts",
-            size: 227,
-            type: "file",
-          },
-          {
-            path: "/subproject",
-            size: 425,
-            type: "dir",
-          },
-          {
-            path: "/subproject/README.md",
-            size: 354,
-            type: "file",
-          },
-          {
-            path: "/subproject/mod.ts",
-            size: 71,
-            type: "file",
-          },
-        ],
-        upload_options: {
+    try {
+      const id = await database.createBuild({
+        options: {
+          moduleName: "ltest",
           ref: "0.0.9",
           repository: "luca-rand/testing",
           type: "github",
+          version: "0.0.9",
         },
-        uploaded_at: undefined,
-      },
-    );
+        status: "queued",
+      });
 
-    let deps = await s3.getObject("ltest/versions/0.0.9/meta/deps_v2.json");
-    assertEquals(deps?.cacheControl, "max-age=10, must-revalidate");
-    assertEquals(deps?.contentType, "application/json");
-    // Check that meta file exists
-    assertEquals(
-      JSON.parse(
-        decoder.decode(
-          deps?.body,
-        ),
-      ),
-      {
-        graph: {
-          nodes: {
-            "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/deps.ts": {
-              deps: ["https://deno.land/std@0.64.0/uuid/mod.ts"],
+      await handler(
+        createSQSEvent({ buildID: id }),
+        createContext(),
+      );
+
+      assertEquals({ ...await database.getBuild(id), created_at: undefined }, {
+        created_at: undefined,
+        id,
+        options: {
+          moduleName: "ltest",
+          ref: "0.0.9",
+          repository: "luca-rand/testing",
+          type: "github",
+          version: "0.0.9",
+        },
+        status: "success",
+        message: "Published module.",
+        stats: {
+          skipped_due_to_size: [],
+          total_files: 11,
+          total_size: 2735,
+        },
+      });
+
+      // Check that versions.json file exists
+      let versions = await s3.getObject("ltest/meta/versions.json");
+      assertEquals(versions?.cacheControl, "max-age=10, must-revalidate");
+      assertEquals(versions?.contentType, "application/json");
+      assertEquals(
+        JSON.parse(decoder.decode(versions?.body)),
+        { latest: "0.0.9", versions: ["0.0.9"] },
+      );
+
+      let meta = await s3.getObject("ltest/versions/0.0.9/meta/meta.json");
+      assertEquals(meta?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(meta?.contentType, "application/json");
+      // Check that meta file exists
+      assertEquals(
+        {
+          ...JSON.parse(
+            decoder.decode(
+              meta?.body,
+            ),
+          ),
+          uploaded_at: undefined,
+        },
+        {
+          directory_listing: [
+            {
+              path: "",
+              size: 2735,
+              type: "dir",
+            },
+            {
+              path: "/.github",
+              size: 716,
+              type: "dir",
+            },
+            {
+              path: "/.github/README.md",
+              size: 304,
+              type: "file",
+            },
+            {
+              path: "/.github/workflows",
+              size: 412,
+              type: "dir",
+            },
+            {
+              path: "/.github/workflows/ci.yml",
+              size: 412,
+              type: "file",
+            },
+            {
+              path: "/.vscode",
+              size: 26,
+              type: "dir",
+            },
+            {
+              path: "/.vscode/settings.json",
+              size: 26,
+              type: "file",
+            },
+            {
+              path: "/LICENSE",
+              size: 1066,
+              type: "file",
+            },
+            {
+              path: "/deps.ts",
               size: 63,
+              type: "file",
             },
-            "https://deno.land/std@0.64.0/uuid/mod.ts": {
-              deps: [
-                "https://deno.land/std@0.64.0/uuid/v1.ts",
-                "https://deno.land/std@0.64.0/uuid/v4.ts",
-                "https://deno.land/std@0.64.0/uuid/v5.ts",
-              ],
-              size: 601,
+            {
+              path: "/example.ts",
+              size: 50,
+              type: "file",
             },
-            "https://deno.land/std@0.64.0/uuid/v1.ts": {
-              deps: ["https://deno.land/std@0.64.0/uuid/_common.ts"],
-              size: 2545,
+            {
+              path: "/fixtures",
+              size: 23,
+              type: "dir",
             },
-            "https://deno.land/std@0.64.0/uuid/_common.ts": {
-              deps: [],
-              size: 1207,
+            {
+              path: "/fixtures/%",
+              size: 23,
+              type: "file",
             },
-            "https://deno.land/std@0.64.0/uuid/v4.ts": {
-              deps: ["https://deno.land/std@0.64.0/uuid/_common.ts"],
-              size: 542,
-            },
-            "https://deno.land/std@0.64.0/uuid/v5.ts": {
-              deps: [
-                "https://deno.land/std@0.64.0/uuid/_common.ts",
-                "https://deno.land/std@0.64.0/hash/sha1.ts",
-                "https://deno.land/std@0.64.0/node/util.ts",
-                "https://deno.land/std@0.64.0/_util/assert.ts",
-              ],
-              size: 1340,
-            },
-            "https://deno.land/std@0.64.0/hash/sha1.ts": {
-              deps: [],
-              size: 11033,
-            },
-            "https://deno.land/std@0.64.0/node/util.ts": {
-              deps: [
-                "https://deno.land/std@0.64.0/node/_util/_util_promisify.ts",
-                "https://deno.land/std@0.64.0/node/_util/_util_callbackify.ts",
-                "https://deno.land/std@0.64.0/node/_util/_util_types.ts",
-                "https://deno.land/std@0.64.0/node/_utils.ts",
-              ],
-              size: 2298,
-            },
-            "https://deno.land/std@0.64.0/node/_util/_util_promisify.ts": {
-              deps: [],
-              size: 4839,
-            },
-            "https://deno.land/std@0.64.0/node/_util/_util_callbackify.ts": {
-              deps: [],
-              size: 4287,
-            },
-            "https://deno.land/std@0.64.0/node/_util/_util_types.ts": {
-              deps: [],
-              size: 7362,
-            },
-            "https://deno.land/std@0.64.0/node/_utils.ts": {
-              deps: [],
-              size: 3807,
-            },
-            "https://deno.land/std@0.64.0/_util/assert.ts": {
-              deps: [],
-              size: 405,
-            },
-            "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/example.ts":
-              {
-                deps: [
-                  "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod.ts",
-                ],
-                size: 50,
-              },
-            "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod.ts": {
-              deps: [
-                "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/deps.ts",
-              ],
+            {
+              path: "/mod.ts",
               size: 139,
+              type: "file",
             },
-            "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod_test.ts":
-              {
-                deps: ["https://deno.land/std@0.64.0/testing/asserts.ts"],
-                size: 227,
+            {
+              path: "/mod_test.ts",
+              size: 227,
+              type: "file",
+            },
+            {
+              path: "/subproject",
+              size: 425,
+              type: "dir",
+            },
+            {
+              path: "/subproject/README.md",
+              size: 354,
+              type: "file",
+            },
+            {
+              path: "/subproject/mod.ts",
+              size: 71,
+              type: "file",
+            },
+          ],
+          upload_options: {
+            ref: "0.0.9",
+            repository: "luca-rand/testing",
+            type: "github",
+          },
+          uploaded_at: undefined,
+        },
+      );
+
+      let deps = await s3.getObject("ltest/versions/0.0.9/meta/deps_v2.json");
+      assertEquals(deps?.cacheControl, "max-age=10, must-revalidate");
+      assertEquals(deps?.contentType, "application/json");
+      // Check that meta file exists
+      assertEquals(
+        JSON.parse(
+          decoder.decode(
+            deps?.body,
+          ),
+        ),
+        {
+          graph: {
+            nodes: {
+              "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/deps.ts":
+                {
+                  deps: ["https://deno.land/std@0.64.0/uuid/mod.ts"],
+                  size: 63,
+                },
+              "https://deno.land/std@0.64.0/uuid/mod.ts": {
+                deps: [
+                  "https://deno.land/std@0.64.0/uuid/v1.ts",
+                  "https://deno.land/std@0.64.0/uuid/v4.ts",
+                  "https://deno.land/std@0.64.0/uuid/v5.ts",
+                ],
+                size: 601,
               },
-            "https://deno.land/std@0.64.0/testing/asserts.ts": {
-              deps: [
-                "https://deno.land/std@0.64.0/fmt/colors.ts",
-                "https://deno.land/std@0.64.0/testing/diff.ts",
-              ],
-              size: 12246,
+              "https://deno.land/std@0.64.0/uuid/v1.ts": {
+                deps: ["https://deno.land/std@0.64.0/uuid/_common.ts"],
+                size: 2545,
+              },
+              "https://deno.land/std@0.64.0/uuid/_common.ts": {
+                deps: [],
+                size: 1207,
+              },
+              "https://deno.land/std@0.64.0/uuid/v4.ts": {
+                deps: ["https://deno.land/std@0.64.0/uuid/_common.ts"],
+                size: 542,
+              },
+              "https://deno.land/std@0.64.0/uuid/v5.ts": {
+                deps: [
+                  "https://deno.land/std@0.64.0/uuid/_common.ts",
+                  "https://deno.land/std@0.64.0/hash/sha1.ts",
+                  "https://deno.land/std@0.64.0/node/util.ts",
+                  "https://deno.land/std@0.64.0/_util/assert.ts",
+                ],
+                size: 1340,
+              },
+              "https://deno.land/std@0.64.0/hash/sha1.ts": {
+                deps: [],
+                size: 11033,
+              },
+              "https://deno.land/std@0.64.0/node/util.ts": {
+                deps: [
+                  "https://deno.land/std@0.64.0/node/_util/_util_promisify.ts",
+                  "https://deno.land/std@0.64.0/node/_util/_util_callbackify.ts",
+                  "https://deno.land/std@0.64.0/node/_util/_util_types.ts",
+                  "https://deno.land/std@0.64.0/node/_utils.ts",
+                ],
+                size: 2298,
+              },
+              "https://deno.land/std@0.64.0/node/_util/_util_promisify.ts": {
+                deps: [],
+                size: 4839,
+              },
+              "https://deno.land/std@0.64.0/node/_util/_util_callbackify.ts": {
+                deps: [],
+                size: 4287,
+              },
+              "https://deno.land/std@0.64.0/node/_util/_util_types.ts": {
+                deps: [],
+                size: 7362,
+              },
+              "https://deno.land/std@0.64.0/node/_utils.ts": {
+                deps: [],
+                size: 3807,
+              },
+              "https://deno.land/std@0.64.0/_util/assert.ts": {
+                deps: [],
+                size: 405,
+              },
+              "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/example.ts":
+                {
+                  deps: [
+                    "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod.ts",
+                  ],
+                  size: 50,
+                },
+              "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod.ts": {
+                deps: [
+                  "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/deps.ts",
+                ],
+                size: 139,
+              },
+              "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/mod_test.ts":
+                {
+                  deps: ["https://deno.land/std@0.64.0/testing/asserts.ts"],
+                  size: 227,
+                },
+              "https://deno.land/std@0.64.0/testing/asserts.ts": {
+                deps: [
+                  "https://deno.land/std@0.64.0/fmt/colors.ts",
+                  "https://deno.land/std@0.64.0/testing/diff.ts",
+                ],
+                size: 12246,
+              },
+              "https://deno.land/std@0.64.0/fmt/colors.ts": {
+                deps: [],
+                size: 5774,
+              },
+              "https://deno.land/std@0.64.0/testing/diff.ts": {
+                deps: [],
+                size: 5473,
+              },
+              "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/subproject/mod.ts":
+                { deps: [], size: 71 },
             },
-            "https://deno.land/std@0.64.0/fmt/colors.ts": {
-              deps: [],
-              size: 5774,
-            },
-            "https://deno.land/std@0.64.0/testing/diff.ts": {
-              deps: [],
-              size: 5473,
-            },
-            "http://s3:9000/deno-registry2/ltest/versions/0.0.9/raw/subproject/mod.ts":
-              { deps: [], size: 71 },
           },
         },
-      },
-    );
+      );
 
-    // Check the yml file was uploaded
-    let yml = await s3.getObject(
-      "ltest/versions/0.0.9/raw/.github/workflows/ci.yml",
-    );
-    assertEquals(yml?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(yml?.contentType, "text/yaml");
-    assertEquals(yml?.body.length, 412);
+      // Check the yml file was uploaded
+      let yml = await s3.getObject(
+        "ltest/versions/0.0.9/raw/.github/workflows/ci.yml",
+      );
+      assertEquals(yml?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(yml?.contentType, "text/yaml");
+      assertEquals(yml?.body.length, 412);
 
-    // Check the ts file was uploaded
-    let ts = await s3.getObject("ltest/versions/0.0.9/raw/mod.ts");
-    assertEquals(ts?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(ts?.contentType, "application/typescript; charset=utf-8");
-    assertEquals(ts?.body.length, 139);
+      // Check the ts file was uploaded
+      let ts = await s3.getObject("ltest/versions/0.0.9/raw/mod.ts");
+      assertEquals(ts?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(ts?.contentType, "application/typescript; charset=utf-8");
+      assertEquals(ts?.body.length, 139);
 
-    // Check the ts file was uploaded
-    let readme = await s3.getObject(
-      "ltest/versions/0.0.9/raw/.github/README.md",
-    );
-    assertEquals(readme?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(readme?.contentType, "text/markdown");
-    assertEquals(readme?.body.length, 304);
-
-    // Cleanup
-    await database._builds.deleteMany({});
-    await s3.deleteObject("ltest/meta/versions.json");
-    await s3.deleteObject("ltest/versions/0.0.9/meta/meta.json");
-    await s3.deleteObject("ltest/versions/0.0.9/meta/deps_v2.json");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/.github/workflows/ci.yml");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/.vscode/settings.json");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/LICENCE");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/deps.ts");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/fixtures/%");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/mod.ts");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/mod_test.md");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/subproject/README.md");
-    await s3.deleteObject("ltest/versions/0.0.9/raw/subproject/mod.ts");
+      // Check the ts file was uploaded
+      let readme = await s3.getObject(
+        "ltest/versions/0.0.9/raw/.github/README.md",
+      );
+      assertEquals(readme?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(readme?.contentType, "text/markdown");
+      assertEquals(readme?.body.length, 304);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest/meta/versions.json");
+      await s3.deleteObject("ltest/versions/0.0.9/meta/meta.json");
+      await s3.deleteObject("ltest/versions/0.0.9/meta/deps_v2.json");
+      await s3.deleteObject(
+        "ltest/versions/0.0.9/raw/.github/workflows/ci.yml",
+      );
+      await s3.deleteObject("ltest/versions/0.0.9/raw/.vscode/settings.json");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/LICENCE");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/deps.ts");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/fixtures/%");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/mod.ts");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/mod_test.md");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/subproject/README.md");
+      await s3.deleteObject("ltest/versions/0.0.9/raw/subproject/mod.ts");
+    }
   },
 });
 
 Deno.test({
   name: "publish success subdir",
   async fn() {
-    const id = await database.createBuild({
-      options: {
-        moduleName: "ltest",
-        ref: "0.0.7",
-        repository: "luca-rand/testing",
-        type: "github",
-        version: "0.0.7",
-        subdir: "subproject/",
-      },
-      status: "queued",
-    });
-
-    await handler(
-      createSQSEvent({ buildID: id }),
-      createContext(),
-    );
-
-    assertEquals({ ...await database.getBuild(id), created_at: undefined }, {
-      created_at: undefined,
-      id,
-      options: {
-        moduleName: "ltest",
-        ref: "0.0.7",
-        repository: "luca-rand/testing",
-        type: "github",
-        version: "0.0.7",
-        subdir: "subproject/",
-      },
-      status: "success",
-      message: "Published module.",
-      stats: {
-        skipped_due_to_size: [],
-        total_files: 2,
-        total_size: 425,
-      },
-    });
-
-    // Check that versions.json file exists
-    let versions = await s3.getObject("ltest/meta/versions.json");
-    assertEquals(versions?.cacheControl, "max-age=10, must-revalidate");
-    assertEquals(versions?.contentType, "application/json");
-    assertEquals(
-      JSON.parse(decoder.decode(versions?.body)),
-      { latest: "0.0.7", versions: ["0.0.7"] },
-    );
-
-    let meta = await s3.getObject("ltest/versions/0.0.7/meta/meta.json");
-    assertEquals(meta?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(meta?.contentType, "application/json");
-    // Check that meta file exists
-    assertEquals(
-      {
-        ...JSON.parse(
-          decoder.decode(
-            meta?.body,
-          ),
-        ),
-        uploaded_at: undefined,
-      },
-      {
-        directory_listing: [
-          {
-            path: "",
-            size: 425,
-            type: "dir",
-          },
-          {
-            path: "/README.md",
-            size: 354,
-            type: "file",
-          },
-          {
-            path: "/mod.ts",
-            size: 71,
-            type: "file",
-          },
-        ],
-        upload_options: {
+    try {
+      const id = await database.createBuild({
+        options: {
+          moduleName: "ltest",
           ref: "0.0.7",
           repository: "luca-rand/testing",
-          subdir: "subproject/",
           type: "github",
+          version: "0.0.7",
+          subdir: "subproject/",
         },
-        uploaded_at: undefined,
-      },
-    );
+        status: "queued",
+      });
 
-    // Check the ts file was uploaded
-    let ts = await s3.getObject("ltest/versions/0.0.7/raw/mod.ts");
-    assertEquals(ts?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(ts?.contentType, "application/typescript; charset=utf-8");
-    assertEquals(ts?.body.length, 71);
+      await handler(
+        createSQSEvent({ buildID: id }),
+        createContext(),
+      );
 
-    // Check the ts file was uploaded
-    let readme = await s3.getObject("ltest/versions/0.0.7/raw/README.md");
-    assertEquals(readme?.cacheControl, "public, max-age=31536000, immutable");
-    assertEquals(readme?.contentType, "text/markdown");
-    assertEquals(readme?.body.length, 354);
+      assertEquals({ ...await database.getBuild(id), created_at: undefined }, {
+        created_at: undefined,
+        id,
+        options: {
+          moduleName: "ltest",
+          ref: "0.0.7",
+          repository: "luca-rand/testing",
+          type: "github",
+          version: "0.0.7",
+          subdir: "subproject/",
+        },
+        status: "success",
+        message: "Published module.",
+        stats: {
+          skipped_due_to_size: [],
+          total_files: 2,
+          total_size: 425,
+        },
+      });
 
-    // Cleanup
-    await database._builds.deleteMany({});
-    await s3.deleteObject("ltest/meta/versions.json");
-    await s3.deleteObject("ltest/versions/0.0.7/meta/meta.json");
-    await s3.deleteObject("ltest/versions/0.0.7/raw/mod.ts");
-    await s3.deleteObject("ltest/versions/0.0.7/raw/README.md");
+      // Check that versions.json file exists
+      let versions = await s3.getObject("ltest/meta/versions.json");
+      assertEquals(versions?.cacheControl, "max-age=10, must-revalidate");
+      assertEquals(versions?.contentType, "application/json");
+      assertEquals(
+        JSON.parse(decoder.decode(versions?.body)),
+        { latest: "0.0.7", versions: ["0.0.7"] },
+      );
+
+      let meta = await s3.getObject("ltest/versions/0.0.7/meta/meta.json");
+      assertEquals(meta?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(meta?.contentType, "application/json");
+      // Check that meta file exists
+      assertEquals(
+        {
+          ...JSON.parse(
+            decoder.decode(
+              meta?.body,
+            ),
+          ),
+          uploaded_at: undefined,
+        },
+        {
+          directory_listing: [
+            {
+              path: "",
+              size: 425,
+              type: "dir",
+            },
+            {
+              path: "/README.md",
+              size: 354,
+              type: "file",
+            },
+            {
+              path: "/mod.ts",
+              size: 71,
+              type: "file",
+            },
+          ],
+          upload_options: {
+            ref: "0.0.7",
+            repository: "luca-rand/testing",
+            subdir: "subproject/",
+            type: "github",
+          },
+          uploaded_at: undefined,
+        },
+      );
+
+      // Check the ts file was uploaded
+      let ts = await s3.getObject("ltest/versions/0.0.7/raw/mod.ts");
+      assertEquals(ts?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(ts?.contentType, "application/typescript; charset=utf-8");
+      assertEquals(ts?.body.length, 71);
+
+      // Check the ts file was uploaded
+      let readme = await s3.getObject("ltest/versions/0.0.7/raw/README.md");
+      assertEquals(readme?.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(readme?.contentType, "text/markdown");
+      assertEquals(readme?.body.length, 354);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest/meta/versions.json");
+      await s3.deleteObject("ltest/versions/0.0.7/meta/meta.json");
+      await s3.deleteObject("ltest/versions/0.0.7/raw/mod.ts");
+      await s3.deleteObject("ltest/versions/0.0.7/raw/README.md");
+    }
   },
 });

--- a/api/async/stargazers_test.ts
+++ b/api/async/stargazers_test.ts
@@ -1,5 +1,6 @@
 import { assert } from "../../test_deps.ts";
 import {
+  cleanupDatabase,
   createContext,
   createScheduledEvent,
 } from "../../utils/test_utils.ts";
@@ -36,19 +37,20 @@ const utest: Module = {
 Deno.test({
   name: "crawl stargazers",
   async fn() {
-    await database.saveModule(ltest);
-    await database.saveModule(utest);
+    try {
+      await database.saveModule(ltest);
+      await database.saveModule(utest);
 
-    await handler(
-      createScheduledEvent(),
-      createContext(),
-    );
+      await handler(
+        createScheduledEvent(),
+        createContext(),
+      );
 
-    const updated = await database.getModule(ltest.name);
-    assert(updated?.star_count ?? 0 >= 1);
-    assertEquals(updated?.created_at, ltest.created_at);
-
-    // Cleanup
-    await database._modules.deleteMany({});
+      const updated = await database.getModule(ltest.name);
+      assert(updated?.star_count ?? 0 >= 1);
+      assertEquals(updated?.created_at, ltest.created_at);
+    } finally {
+      await cleanupDatabase(database);
+    }
   },
 });

--- a/api/modules/get_test.ts
+++ b/api/modules/get_test.ts
@@ -1,5 +1,6 @@
 import { handler } from "./get.ts";
 import {
+  cleanupDatabase,
   createAPIGatewayProxyEventV2,
   createContext,
 } from "../../utils/test_utils.ts";
@@ -11,40 +12,44 @@ const database = new Database(Deno.env.get("MONGO_URI")!);
 Deno.test({
   name: "`/modules/:name` success",
   async fn() {
-    await database.saveModule({
-      name: "ltest",
-      description: "ltest repo",
-      owner: "luca-rand",
-      repo: "testing",
-      star_count: 50,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+    try {
+      await database.saveModule({
+        name: "ltest",
+        description: "ltest repo",
+        owner: "luca-rand",
+        repo: "testing",
+        star_count: 50,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    const res = await handler(
-      createAPIGatewayProxyEventV2(
-        "GET",
-        "/modules/ltest",
-        { pathParameters: { name: "ltest" } },
-      ),
-      createContext(),
-    );
+      const res = await handler(
+        createAPIGatewayProxyEventV2(
+          "GET",
+          "/modules/ltest",
+          { pathParameters: { name: "ltest" } },
+        ),
+        createContext(),
+      );
 
-    assertEquals(
-      res,
-      {
-        body:
-          '{"success":true,"data":{"name":"ltest","description":"ltest repo","star_count":50}}',
-        headers: {
-          "content-type": "application/json",
+      assertEquals(
+        res,
+        {
+          body:
+            '{"success":true,"data":{"name":"ltest","description":"ltest repo","star_count":50}}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 200,
         },
-        statusCode: 200,
-      },
-    );
+      );
 
-    // Cleanup
-    await database._modules.deleteMany({});
+      // Cleanup
+      await database._modules.deleteMany({});
+    } finally {
+      await cleanupDatabase(database);
+    }
   },
 });
 

--- a/api/modules/list_test.ts
+++ b/api/modules/list_test.ts
@@ -1,5 +1,6 @@
 import { handler } from "./list.ts";
 import {
+  cleanupDatabase,
   createAPIGatewayProxyEventV2,
   createContext,
 } from "../../utils/test_utils.ts";
@@ -11,211 +12,213 @@ const database = new Database(Deno.env.get("MONGO_URI")!);
 Deno.test({
   name: "`/modules` success",
   async fn() {
-    for (let i = 0; i < 5; i++) {
-      await database.saveModule({
-        name: `ltest${i}`,
-        description: "ltest repo",
-        owner: "luca-rand",
-        repo: "testing",
-        star_count: i,
-        type: "github",
-        is_unlisted: false,
-        created_at: new Date(2020, 1, 1),
-      });
+    try {
+      for (let i = 0; i < 5; i++) {
+        await database.saveModule({
+          name: `ltest${i}`,
+          description: "ltest repo",
+          owner: "luca-rand",
+          repo: "testing",
+          star_count: i,
+          type: "github",
+          is_unlisted: false,
+          created_at: new Date(2020, 1, 1),
+        });
+      }
+
+      const res = await handler(
+        createAPIGatewayProxyEventV2("GET", "/modules", {}),
+        createContext(),
+      );
+
+      assertEquals(
+        res,
+        {
+          body:
+            '{"success":true,"data":{"total_count":5,"results":[{"name":"ltest4","description":"ltest repo","star_count":4},{"name":"ltest3","description":"ltest repo","star_count":3},{"name":"ltest2","description":"ltest repo","star_count":2},{"name":"ltest1","description":"ltest repo","star_count":1},{"name":"ltest0","description":"ltest repo","star_count":0}]}}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 200,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules?simple=1", {
+            queryStringParameters: {
+              simple: "1",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body: '["ltest0","ltest1","ltest2","ltest3","ltest4"]',
+          headers: {
+            "cache-control": "max-age=60, must-revalidate",
+            "content-type": "application/json",
+          },
+          statusCode: 200,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              page: "2",
+              limit: "2",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":true,"data":{"total_count":5,"results":[{"name":"ltest2","description":"ltest repo","star_count":2},{"name":"ltest1","description":"ltest repo","star_count":1}]}}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 200,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              page: "5",
+              limit: "2",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body: '{"success":true,"data":{"total_count":5,"results":[]}}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 200,
+        },
+      );
+    } finally {
+      await cleanupDatabase(database);
     }
-
-    const res = await handler(
-      createAPIGatewayProxyEventV2("GET", "/modules", {}),
-      createContext(),
-    );
-
-    assertEquals(
-      res,
-      {
-        body:
-          '{"success":true,"data":{"total_count":5,"results":[{"name":"ltest4","description":"ltest repo","star_count":4},{"name":"ltest3","description":"ltest repo","star_count":3},{"name":"ltest2","description":"ltest repo","star_count":2},{"name":"ltest1","description":"ltest repo","star_count":1},{"name":"ltest0","description":"ltest repo","star_count":0}]}}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 200,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules?simple=1", {
-          queryStringParameters: {
-            simple: "1",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body: '["ltest0","ltest1","ltest2","ltest3","ltest4"]',
-        headers: {
-          "cache-control": "max-age=60, must-revalidate",
-          "content-type": "application/json",
-        },
-        statusCode: 200,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            page: "2",
-            limit: "2",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":true,"data":{"total_count":5,"results":[{"name":"ltest2","description":"ltest repo","star_count":2},{"name":"ltest1","description":"ltest repo","star_count":1}]}}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 200,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            page: "5",
-            limit: "2",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body: '{"success":true,"data":{"total_count":5,"results":[]}}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 200,
-      },
-    );
-
-    // Cleanup
-    await database._modules.deleteMany({});
   },
 });
 
 Deno.test({
   name: "`/modules` limit & page out of bounds",
   async fn() {
-    for (let i = 0; i < 5; i++) {
-      await database.saveModule({
-        name: `ltest${i}`,
-        description: "ltest repo",
-        owner: "luca-rand",
-        repo: "testing",
-        star_count: i,
-        type: "github",
-        is_unlisted: false,
-        created_at: new Date(2020, 1, 1),
-      });
+    try {
+      for (let i = 0; i < 5; i++) {
+        await database.saveModule({
+          name: `ltest${i}`,
+          description: "ltest repo",
+          owner: "luca-rand",
+          repo: "testing",
+          star_count: i,
+          type: "github",
+          is_unlisted: false,
+          created_at: new Date(2020, 1, 1),
+        });
+      }
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              page: "0",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":false,"error":"the page number must not be lower than 1"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              page: "-1",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":false,"error":"the page number must not be lower than 1"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              limit: "0",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":false,"error":"the limit may not be larger than 100 or smaller than 1"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              limit: "-1",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":false,"error":"the limit may not be larger than 100 or smaller than 1"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
+        },
+      );
+
+      assertEquals(
+        await handler(
+          createAPIGatewayProxyEventV2("GET", "/modules", {
+            queryStringParameters: {
+              limit: "101",
+            },
+          }),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":false,"error":"the limit may not be larger than 100 or smaller than 1"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
+        },
+      );
+    } finally {
+      await cleanupDatabase(database);
     }
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            page: "0",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"the page number must not be lower than 1"}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 400,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            page: "-1",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"the page number must not be lower than 1"}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 400,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            limit: "0",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"the limit may not be larger than 100 or smaller than 1"}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 400,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            limit: "-1",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"the limit may not be larger than 100 or smaller than 1"}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 400,
-      },
-    );
-
-    assertEquals(
-      await handler(
-        createAPIGatewayProxyEventV2("GET", "/modules", {
-          queryStringParameters: {
-            limit: "101",
-          },
-        }),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"the limit may not be larger than 100 or smaller than 1"}',
-        headers: {
-          "content-type": "application/json",
-        },
-        statusCode: 400,
-      },
-    );
-
-    // Cleanup
-    await database._modules.deleteMany({});
   },
 });

--- a/api/stats_test.ts
+++ b/api/stats_test.ts
@@ -2,6 +2,7 @@ import { handler } from "./stats.ts";
 import {
   createAPIGatewayProxyEventV2,
   createContext,
+  cleanupDatabase,
 } from "../utils/test_utils.ts";
 import { assertEquals } from "../test_deps.ts";
 import { Database } from "../utils/database.ts";
@@ -11,121 +12,121 @@ const database = new Database(Deno.env.get("MONGO_URI")!);
 Deno.test({
   name: "`/stats` success",
   async fn() {
-    await database.saveModule({
-      name: "ltest1",
-      description: "ltest1 repo",
-      owner: "luca-rand",
-      repo: "testing",
-      star_count: 50,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 3),
-    });
-
-    await database.saveModule({
-      name: "ltest2",
-      description: "ltest2 repo",
-      owner: "luca-rand",
-      repo: "testing",
-      star_count: 50,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-
-    await database.saveModule({
-      name: "ltest3",
-      description: "ltest3 repo",
-      owner: "luca-rand",
-      repo: "testing",
-      star_count: 50,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 2),
-    });
-
-    await database.saveModule({
-      name: "ltest4",
-      description: "ltest4 repo",
-      owner: "luca-rand",
-      repo: "testing",
-      star_count: 50,
-      type: "github",
-      is_unlisted: true,
-      created_at: new Date(2020, 1, 3),
-    });
-
-    await database._builds.insertMany([
-      {
-        created_at: new Date(2020, 1, 1),
-        options: {
-          moduleName: "ltest",
-          ref: "0.1.0",
-          repository: "luca-rand/testing",
-          type: "github",
-          version: "0.1.0",
-        },
-        status: "queued",
-      },
-      {
-        created_at: new Date(2020, 1, 2),
-        options: {
-          moduleName: "ltest2",
-          ref: "0.1.0",
-          repository: "luca-rand/testing",
-          type: "github",
-          version: "0.1.0",
-        },
-        status: "queued",
-      },
-      {
-        created_at: new Date(2020, 1, 4),
-        options: {
-          moduleName: "ltest",
-          ref: "0.2.0",
-          repository: "luca-rand/testing",
-          type: "github",
-          version: "0.2.0",
-        },
-        status: "queued",
-      },
-      {
+    try {
+      await database.saveModule({
+        name: "ltest1",
+        description: "ltest1 repo",
+        owner: "luca-rand",
+        repo: "testing",
+        star_count: 50,
+        type: "github",
+        is_unlisted: false,
         created_at: new Date(2020, 1, 3),
-        options: {
-          moduleName: "ltest3",
-          ref: "0.3.0",
-          repository: "luca-rand/testing",
-          type: "github",
-          version: "0.3.0",
-          subdir: "subproject/",
+      });
+
+      await database.saveModule({
+        name: "ltest2",
+        description: "ltest2 repo",
+        owner: "luca-rand",
+        repo: "testing",
+        star_count: 50,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+
+      await database.saveModule({
+        name: "ltest3",
+        description: "ltest3 repo",
+        owner: "luca-rand",
+        repo: "testing",
+        star_count: 50,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 2),
+      });
+
+      await database.saveModule({
+        name: "ltest4",
+        description: "ltest4 repo",
+        owner: "luca-rand",
+        repo: "testing",
+        star_count: 50,
+        type: "github",
+        is_unlisted: true,
+        created_at: new Date(2020, 1, 3),
+      });
+
+      await database._builds.insertMany([
+        {
+          created_at: new Date(2020, 1, 1),
+          options: {
+            moduleName: "ltest",
+            ref: "0.1.0",
+            repository: "luca-rand/testing",
+            type: "github",
+            version: "0.1.0",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    ]);
-
-    const res = await handler(
-      createAPIGatewayProxyEventV2(
-        "GET",
-        "/stats",
-        {},
-      ),
-      createContext(),
-    );
-
-    assertEquals(
-      res,
-      {
-        body:
-          '{"success":true,"data":{"total_count":3,"total_versions":4,"recently_added_modules":[{"name":"ltest1","description":"ltest1 repo","star_count":50,"created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest3","description":"ltest3 repo","star_count":50,"created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest2","description":"ltest2 repo","star_count":50,"created_at":"2020-02-01T00:00:00.000Z"}],"recently_uploaded_versions":[{"name":"ltest","version":"0.2.0","created_at":"2020-02-04T00:00:00.000Z"},{"name":"ltest3","version":"0.3.0","created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest2","version":"0.1.0","created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest","version":"0.1.0","created_at":"2020-02-01T00:00:00.000Z"}]}}',
-        headers: {
-          "content-type": "application/json",
+        {
+          created_at: new Date(2020, 1, 2),
+          options: {
+            moduleName: "ltest2",
+            ref: "0.1.0",
+            repository: "luca-rand/testing",
+            type: "github",
+            version: "0.1.0",
+          },
+          status: "queued",
         },
-        statusCode: 200,
-      },
-    );
+        {
+          created_at: new Date(2020, 1, 4),
+          options: {
+            moduleName: "ltest",
+            ref: "0.2.0",
+            repository: "luca-rand/testing",
+            type: "github",
+            version: "0.2.0",
+          },
+          status: "queued",
+        },
+        {
+          created_at: new Date(2020, 1, 3),
+          options: {
+            moduleName: "ltest3",
+            ref: "0.3.0",
+            repository: "luca-rand/testing",
+            type: "github",
+            version: "0.3.0",
+            subdir: "subproject/",
+          },
+          status: "queued",
+        },
+      ]);
 
-    // Cleanup
-    await database._modules.deleteMany({});
-    await database._builds.deleteMany({});
+      const res = await handler(
+        createAPIGatewayProxyEventV2(
+          "GET",
+          "/stats",
+          {},
+        ),
+        createContext(),
+      );
+
+      assertEquals(
+        res,
+        {
+          body:
+            '{"success":true,"data":{"total_count":3,"total_versions":4,"recently_added_modules":[{"name":"ltest1","description":"ltest1 repo","star_count":50,"created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest3","description":"ltest3 repo","star_count":50,"created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest2","description":"ltest2 repo","star_count":50,"created_at":"2020-02-01T00:00:00.000Z"}],"recently_uploaded_versions":[{"name":"ltest","version":"0.2.0","created_at":"2020-02-04T00:00:00.000Z"},{"name":"ltest3","version":"0.3.0","created_at":"2020-02-03T00:00:00.000Z"},{"name":"ltest2","version":"0.1.0","created_at":"2020-02-02T00:00:00.000Z"},{"name":"ltest","version":"0.1.0","created_at":"2020-02-01T00:00:00.000Z"}]}}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 200,
+        },
+      );
+    } finally {
+      await cleanupDatabase(database);
+    }
   },
 });

--- a/api/webhook/github_create_test.ts
+++ b/api/webhook/github_create_test.ts
@@ -3,6 +3,7 @@ import {
   createJSONWebhookEvent,
   createJSONWebhookWebFormEvent,
   createContext,
+  cleanupDatabase,
 } from "../../utils/test_utils.ts";
 import { Database } from "../../utils/database.ts";
 import { assertEquals, assert } from "../../test_deps.ts";
@@ -36,804 +37,878 @@ const createeventVersionPrefix = JSON.parse(
 Deno.test({
   name: "create event no name",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/",
-        createevent,
-        { name: "" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"no module name specified"}',
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/",
+          createevent,
+          { name: "" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"no module name specified"}',
 
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
+    } finally {
+      await cleanupDatabase(database);
+    }
   },
 });
 
 Deno.test({
   name: "create event bad name",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest-2",
-        createevent,
-        { name: "ltest-2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"module name is not valid"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest-2",
+          createevent,
+          { name: "ltest-2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"module name is not valid"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest-2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest-2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event forbidden name",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/frisbee",
-        createeventforbidden,
-        { name: "frisbee" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"found forbidden word in module name"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
-
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("frisbee", "versions.json"), undefined);
-
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("frisbee"), null);
-  },
-});
-
-Deno.test({
-  name: "create event max registered to repository",
-  async fn() {
-    await database.saveModule({
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-    await database.saveModule({
-      name: "ltest3",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-    await database.saveModule({
-      name: "ltest4",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-
-    // Send create event for ltest5
-    assertEquals(
-      await handler(
+    try {
+      // Send create event
+      const resp = await handler(
         createJSONWebhookEvent(
           "create",
-          "/webhook/gh/ltest5",
-          createevent,
-          { name: "ltest5" },
+          "/webhook/gh/frisbee",
+          createeventforbidden,
+          { name: "frisbee" },
           {},
         ),
         createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"Max number of modules for one repository (3) has been reached. Please contact ry@deno.land if you need more."}',
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"found forbidden word in module name"}',
         headers: {
           "content-type": "application/json",
         },
         statusCode: 400,
-      },
-    );
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest5", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("frisbee", "versions.json"), undefined);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest5"), null);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that builds were queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await database._modules.deleteMany({});
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("frisbee"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("frisbee/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event max registered to repository",
   async fn() {
-    for (let i = 0; i < 15; i++) {
+    try {
       await database.saveModule({
-        name: `ltest${i + 2}`,
+        name: "ltest2",
         type: "github",
         owner: "luca-rand",
-        repo: `testing${i + 2}`,
+        repo: "testing",
         description: "",
         star_count: 4,
         is_unlisted: false,
         created_at: new Date(2020, 1, 1),
       });
-    }
+      await database.saveModule({
+        name: "ltest3",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest4",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send create event for ltest5
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "create",
-          "/webhook/gh/ltest17",
-          createevent,
-          { name: "ltest17" },
-          {},
+      // Send create event for ltest5
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "create",
+            "/webhook/gh/ltest5",
+            createevent,
+            { name: "ltest5" },
+            {},
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"Max number of modules for one user/org (15) has been reached. Please contact ry@deno.land if you need more."}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"Max number of modules for one repository (3) has been reached. Please contact ry@deno.land if you need more."}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest17", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest5", "versions.json"), undefined);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest17"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest5"), null);
 
-    // Check that builds were queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that builds were queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.deleteObject("ltest3/meta/versions.json");
+      await s3.deleteObject("ltest4/meta/versions.json");
+      await s3.deleteObject("ltest5/meta/versions.json");
+    }
+  },
+});
 
-    // Clean up
-    await database._modules.deleteMany({});
+Deno.test({
+  name: "create event max registered to repository",
+  async fn() {
+    try {
+      for (let i = 0; i < 15; i++) {
+        await database.saveModule({
+          name: `ltest${i + 2}`,
+          type: "github",
+          owner: "luca-rand",
+          repo: `testing${i + 2}`,
+          description: "",
+          star_count: 4,
+          is_unlisted: false,
+          created_at: new Date(2020, 1, 1),
+        });
+      }
+
+      // Send create event for ltest5
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "create",
+            "/webhook/gh/ltest17",
+            createevent,
+            { name: "ltest17" },
+            {},
+          ),
+          createContext(),
+        ),
+        {
+          body:
+            '{"success":false,"error":"Max number of modules for one user/org (15) has been reached. Please contact ry@deno.land if you need more."}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
+        },
+      );
+
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest17", "versions.json"), undefined);
+
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest17"), null);
+
+      // Check that builds were queued
+      assertEquals(await database._builds.find({}), []);
+
+      // Clean up
+      await database._modules.deleteMany({});
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.deleteObject("ltest3/meta/versions.json");
+      await s3.deleteObject("ltest4/meta/versions.json");
+      await s3.deleteObject("ltest5/meta/versions.json");
+      await s3.deleteObject("ltest6/meta/versions.json");
+      await s3.deleteObject("ltest7/meta/versions.json");
+      await s3.deleteObject("ltest8/meta/versions.json");
+      await s3.deleteObject("ltest9/meta/versions.json");
+      await s3.deleteObject("ltest10/meta/versions.json");
+      await s3.deleteObject("ltest11/meta/versions.json");
+      await s3.deleteObject("ltest12/meta/versions.json");
+      await s3.deleteObject("ltest13/meta/versions.json");
+      await s3.deleteObject("ltest14/meta/versions.json");
+      await s3.deleteObject("ltest15/meta/versions.json");
+      await s3.deleteObject("ltest16/meta/versions.json");
+      await s3.deleteObject("ltest17/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event max registered to repository with dynamic owner quota",
   async fn() {
-    database.saveOwnerQuota({
-      owner: "luca-rand",
-      type: "github",
-      max_modules: 7,
-    });
-
-    for (let i = 0; i < 7; i++) {
-      await database.saveModule({
-        name: `ltest${i + 2}`,
-        type: "github",
+    try {
+      database.saveOwnerQuota({
         owner: "luca-rand",
-        repo: `testing${i + 2}`,
-        description: "",
-        star_count: 4,
-        is_unlisted: false,
-        created_at: new Date(2020, 1, 1),
+        type: "github",
+        max_modules: 7,
       });
-    }
 
-    // Send create event for ltest5
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "create",
-          "/webhook/gh/ltest9",
-          createevent,
-          { name: "ltest9" },
-          {},
+      for (let i = 0; i < 7; i++) {
+        await database.saveModule({
+          name: `ltest${i + 2}`,
+          type: "github",
+          owner: "luca-rand",
+          repo: `testing${i + 2}`,
+          description: "",
+          star_count: 4,
+          is_unlisted: false,
+          created_at: new Date(2020, 1, 1),
+        });
+      }
+
+      // Send create event for ltest5
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "create",
+            "/webhook/gh/ltest9",
+            createevent,
+            { name: "ltest9" },
+            {},
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"Max number of modules for one user/org (7) has been reached. Please contact ry@deno.land if you need more."}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"Max number of modules for one user/org (7) has been reached. Please contact ry@deno.land if you need more."}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest9", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest9", "versions.json"), undefined);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest9"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest9"), null);
 
-    // Check that builds were queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await database._modules.deleteMany({});
-    await database._owner_quotas.deleteMany({});
+      // Check that builds were queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.deleteObject("ltest3/meta/versions.json");
+      await s3.deleteObject("ltest4/meta/versions.json");
+      await s3.deleteObject("ltest5/meta/versions.json");
+      await s3.deleteObject("ltest6/meta/versions.json");
+      await s3.deleteObject("ltest7/meta/versions.json");
+      await s3.deleteObject("ltest8/meta/versions.json");
+      await s3.deleteObject("ltest9/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event success",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "0.0.7",
-          version: "0.0.7",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event success - web form",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookWebFormEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        btoa(urlencodedcreateevent),
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookWebFormEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          btoa(urlencodedcreateevent),
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "0.0.7",
-          version: "0.0.7",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event not a tag",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createeventBranch,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"info":"created ref is not tag"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createeventBranch,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"info":"created ref is not tag"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event version prefix no match",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createevent,
-        { name: "ltest2" },
-        { version_prefix: "v" },
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":false,"info":"ignoring event as the version does not match the version prefix"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createevent,
+          { name: "ltest2" },
+          { version_prefix: "v" },
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":false,"info":"ignoring event as the version does not match the version prefix"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event version prefix match",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createeventVersionPrefix,
-        { name: "ltest2" },
-        { version_prefix: "v" },
-      ),
-      createContext(),
-    );
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createeventVersionPrefix,
+          { name: "ltest2" },
+          { version_prefix: "v" },
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "v0.0.7",
-          version: "0.0.7",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "v0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event subdir invalid",
   async fn() {
-    // Send create event
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "create",
-          "/webhook/gh/ltest2",
-          createevent,
-          { name: "ltest2" },
-          { subdir: "/asd" },
+    try {
+      // Send create event
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "create",
+            "/webhook/gh/ltest2",
+            createevent,
+            { name: "ltest2" },
+            { subdir: "/asd" },
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"provided sub directory is not valid as it starts with a /"}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"provided sub directory is not valid as it starts with a /"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Send create event
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "create",
-          "/webhook/gh/ltest2",
-          createevent,
-          { name: "ltest2" },
-          { subdir: "asd" },
+      // Send create event
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "create",
+            "/webhook/gh/ltest2",
+            createevent,
+            { name: "ltest2" },
+            { subdir: "asd" },
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"provided sub directory is not valid as it does not end with a /"}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"provided sub directory is not valid as it does not end with a /"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event subdir success",
   async fn() {
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createevent,
-        { name: "ltest2" },
-        { subdir: "asd/" },
-      ),
-      createContext(),
-    );
+    try {
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createevent,
+          { name: "ltest2" },
+          { subdir: "asd/" },
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "0.0.7",
-          version: "0.0.7",
-          subdir: "asd/",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "0.0.7",
+            version: "0.0.7",
+            subdir: "asd/",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event already exists",
   async fn() {
-    await uploadMetaJson(
-      "ltest2",
-      "versions.json",
-      { latest: "0.0.7", versions: ["0.0.7"] },
-    );
+    try {
+      await uploadMetaJson(
+        "ltest2",
+        "versions.json",
+        { latest: "0.0.7", versions: ["0.0.7"] },
+      );
 
-    // Send create event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"version already exists"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+      // Send create event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"version already exists"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that versions.json was not changed
-    assertEquals(
-      JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
-      { latest: "0.0.7", versions: ["0.0.7"] },
-    );
+      // Check that versions.json was not changed
+      assertEquals(
+        JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
+        { latest: "0.0.7", versions: ["0.0.7"] },
+      );
 
-    // Check that no new build was queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no new build was queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
+      // Clean up
+      await s3.deleteObject("ltest2/meta/versions.json");
+      await database._modules.deleteMany({});
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "create event already queued",
   async fn() {
-    await database.createBuild({
-      options: {
-        moduleName: "ltest2",
-        ref: "0.0.7",
-        repository: "luca-rand/testing",
+    try {
+      await database.createBuild({
+        options: {
+          moduleName: "ltest2",
+          ref: "0.0.7",
+          repository: "luca-rand/testing",
+          type: "github",
+          version: "0.0.7",
+        },
+        status: "queued",
+      });
+
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "create",
+          "/webhook/gh/ltest2",
+          createevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":false,"error":"this module version is already being published"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
+
+      // Check that the database entry was created
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
+
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
         type: "github",
-        version: "0.0.7",
-      },
-      status: "queued",
-    });
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "create",
-        "/webhook/gh/ltest2",
-        createevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":false,"error":"this module version is already being published"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
-
-    // Check that the database entry was created
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
-
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
-    await database._builds.deleteMany({});
+      // Clean up
+      await s3.deleteObject("ltest2/meta/versions.json");
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });

--- a/api/webhook/github_ping_test.ts
+++ b/api/webhook/github_ping_test.ts
@@ -3,6 +3,7 @@ import {
   createJSONWebhookEvent,
   createJSONWebhookWebFormEvent,
   createContext,
+  cleanupDatabase,
 } from "../../utils/test_utils.ts";
 import { Database } from "../../utils/database.ts";
 import { assert, assertEquals } from "../../test_deps.ts";
@@ -26,408 +27,433 @@ const urlendodedpingevent = await Deno.readTextFile(
 Deno.test({
   name: "ping event no name",
   async fn() {
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "ping",
-        "/webhook/gh/",
-        pingevent,
-        { name: "" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"no module name specified"}',
+    try {
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "ping",
+          "/webhook/gh/",
+          pingevent,
+          { name: "" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"no module name specified"}',
 
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest-2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest-2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event bad name",
   async fn() {
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "ping",
-        "/webhook/gh/ltest-2",
-        pingevent,
-        { name: "ltest-2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"module name is not valid"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+    try {
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "ping",
+          "/webhook/gh/ltest-2",
+          pingevent,
+          { name: "ltest-2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"module name is not valid"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest-2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest-2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event forbidden name",
   async fn() {
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "ping",
-        "/webhook/gh/frisbee",
-        pingeventforbiddent,
-        { name: "frisbee" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"found forbidden word in module name"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+    try {
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "ping",
+          "/webhook/gh/frisbee",
+          pingeventforbiddent,
+          { name: "frisbee" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"found forbidden word in module name"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("frisbee", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("frisbee", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("frisbee"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("frisbee"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event success",
   async fn() {
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "ping",
-        "/webhook/gh/ltest2",
-        pingevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":true,"data":{"module":"ltest2","repository":"luca-rand/testing"}}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+    try {
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "ping",
+          "/webhook/gh/ltest2",
+          pingevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":true,"data":{"module":"ltest2","repository":"luca-rand/testing"}}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that a versions.json file was created
-    assertEquals(
-      JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
-      { latest: null, versions: [] },
-    );
+      // Check that a versions.json file was created
+      assertEquals(
+        JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
+        { latest: null, versions: [] },
+      );
 
-    // Check that no new build was queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
+      // Check that no new build was queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event success - web form",
   async fn() {
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookWebFormEvent(
-        "ping",
-        "/webhook/gh/ltest2",
-        btoa(urlendodedpingevent),
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":true,"data":{"module":"ltest2","repository":"luca-rand/testing"}}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+    try {
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookWebFormEvent(
+          "ping",
+          "/webhook/gh/ltest2",
+          btoa(urlendodedpingevent),
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":true,"data":{"module":"ltest2","repository":"luca-rand/testing"}}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that a versions.json file was created
-    assertEquals(
-      JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
-      { latest: null, versions: [] },
-    );
+      // Check that a versions.json file was created
+      assertEquals(
+        JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
+        { latest: null, versions: [] },
+      );
 
-    // Check that no new build was queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
+      // Check that no new build was queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event max registered to repository",
   async fn() {
-    await database.saveModule({
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-    await database.saveModule({
-      name: "ltest3",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-    await database.saveModule({
-      name: "ltest4",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+    try {
+      await database.saveModule({
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest3",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest4",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send ping event for ltest5
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "ping",
-          "/webhook/gh/ltest5",
-          pingevent,
-          { name: "ltest5" },
-          {},
+      // Send ping event for ltest5
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "ping",
+            "/webhook/gh/ltest5",
+            pingevent,
+            { name: "ltest5" },
+            {},
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"Max number of modules for one repository (3) has been reached. Please contact ry@deno.land if you need more."}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"Max number of modules for one repository (3) has been reached. Please contact ry@deno.land if you need more."}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest5", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest5", "versions.json"), undefined);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest5"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest5"), null);
 
-    // Check that builds were queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await database._modules.deleteMany({});
+      // Check that builds were queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.deleteObject("ltest3/meta/versions.json");
+      await s3.deleteObject("ltest4/meta/versions.json");
+      await s3.deleteObject("ltest5/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event wrong repository",
   async fn() {
-    database.saveModule({
-      name: "ltest",
-      description: "testing things",
-      owner: "luca-rand",
-      repo: "testing2",
-      star_count: 4,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+    try {
+      database.saveModule({
+        name: "ltest",
+        description: "testing things",
+        owner: "luca-rand",
+        repo: "testing2",
+        star_count: 4,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "ping",
-        "/webhook/gh/ltest",
-        pingevent,
-        { name: "ltest" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":false,"error":"module name is registered to a different repository"}',
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "ping",
+          "/webhook/gh/ltest",
+          pingevent,
+          { name: "ltest" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":false,"error":"module name is registered to a different repository"}',
 
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 409,
-    });
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 409,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    const ltest2 = await database.getModule("ltest");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest",
-      description: "testing things",
-      owner: "luca-rand",
-      repo: "testing2",
-      star_count: 4,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-
-    // Cleanup
-    await database._modules.deleteMany({});
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest",
+        description: "testing things",
+        owner: "luca-rand",
+        repo: "testing2",
+        star_count: 4,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "ping event success capitalization",
   async fn() {
-    database.saveModule({
-      name: "ltest2",
-      description: "testing things",
-      owner: "lUca-rand",
-      repo: "Testing",
-      star_count: 4,
-      type: "github",
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+    try {
+      database.saveModule({
+        name: "ltest2",
+        description: "testing things",
+        owner: "lUca-rand",
+        repo: "Testing",
+        star_count: 4,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send ping event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "ping",
-        "/webhook/gh/ltest2",
-        pingevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":true,"data":{"module":"ltest2","repository":"luca-rand/testing"}}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      // Send ping event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "ping",
+          "/webhook/gh/ltest2",
+          pingevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":true,"data":{"module":"ltest2","repository":"luca-rand/testing"}}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that a versions.json file was created
-    assertEquals(
-      JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
-      { latest: null, versions: [] },
-    );
+      // Check that a versions.json file was created
+      assertEquals(
+        JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
+        { latest: null, versions: [] },
+      );
 
-    // Check that no new build was queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
+      // Check that no new build was queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });

--- a/api/webhook/github_push_test.ts
+++ b/api/webhook/github_push_test.ts
@@ -2,6 +2,7 @@ import { handler } from "./github.ts";
 import {
   createJSONWebhookEvent,
   createContext,
+  cleanupDatabase,
 } from "../../utils/test_utils.ts";
 import { Database } from "../../utils/database.ts";
 import { assertEquals, assert } from "../../test_deps.ts";
@@ -32,621 +33,662 @@ const pusheventVersionPrefix = JSON.parse(
 Deno.test({
   name: "push event no name",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/",
-        pushevent,
-        { name: "" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"no module name specified"}',
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/",
+          pushevent,
+          { name: "" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"no module name specified"}',
 
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
+    } finally {
+      await cleanupDatabase(database);
+    }
   },
 });
 
 Deno.test({
   name: "push event bad name",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest-2",
-        pushevent,
-        { name: "ltest-2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"module name is not valid"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest-2",
+          pushevent,
+          { name: "ltest-2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"module name is not valid"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest-2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest-2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event forbidden name",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/frisbee",
-        pusheventforbidden,
-        { name: "frisbee" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"found forbidden word in module name"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/frisbee",
+          pusheventforbidden,
+          { name: "frisbee" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"found forbidden word in module name"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("frisbee", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("frisbee", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("frisbee"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("frisbee"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("frisbee/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event max registered to repository",
   async fn() {
-    await database.saveModule({
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-    await database.saveModule({
-      name: "ltest3",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-    await database.saveModule({
-      name: "ltest4",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "",
-      star_count: 4,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+    try {
+      await database.saveModule({
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest3",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest4",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send push event for ltest5
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "push",
-          "/webhook/gh/ltest5",
-          pushevent,
-          { name: "ltest5" },
-          {},
+      // Send push event for ltest5
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "push",
+            "/webhook/gh/ltest5",
+            pushevent,
+            { name: "ltest5" },
+            {},
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"Max number of modules for one repository (3) has been reached. Please contact ry@deno.land if you need more."}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"Max number of modules for one repository (3) has been reached. Please contact ry@deno.land if you need more."}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest5", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest5", "versions.json"), undefined);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest5"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest5"), null);
 
-    // Check that builds were queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await database._modules.deleteMany({});
+      // Check that builds were queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.deleteObject("ltest3/meta/versions.json");
+      await s3.deleteObject("ltest4/meta/versions.json");
+      await s3.deleteObject("ltest5/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event success",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pushevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pushevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "0.0.7",
-          version: "0.0.7",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event not a tag",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pusheventBranch,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"info":"created ref is not tag"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pusheventBranch,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"info":"created ref is not tag"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event version prefix no match",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pushevent,
-        { name: "ltest2" },
-        { version_prefix: "v" },
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":false,"info":"ignoring event as the version does not match the version prefix"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pushevent,
+          { name: "ltest2" },
+          { version_prefix: "v" },
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":false,"info":"ignoring event as the version does not match the version prefix"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event version prefix match",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pusheventVersionPrefix,
-        { name: "ltest2" },
-        { version_prefix: "v" },
-      ),
-      createContext(),
-    );
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pusheventVersionPrefix,
+          { name: "ltest2" },
+          { version_prefix: "v" },
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "v0.0.7",
-          version: "0.0.7",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "v0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event subdir invalid",
   async fn() {
-    // Send push event
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "push",
-          "/webhook/gh/ltest2",
-          pushevent,
-          { name: "ltest2" },
-          { subdir: "/asd" },
+    try {
+      // Send push event
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "push",
+            "/webhook/gh/ltest2",
+            pushevent,
+            { name: "ltest2" },
+            { subdir: "/asd" },
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"provided sub directory is not valid as it starts with a /"}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"provided sub directory is not valid as it starts with a /"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Send push event
-    assertEquals(
-      await handler(
-        createJSONWebhookEvent(
-          "push",
-          "/webhook/gh/ltest2",
-          pushevent,
-          { name: "ltest2" },
-          { subdir: "asd" },
+      // Send push event
+      assertEquals(
+        await handler(
+          createJSONWebhookEvent(
+            "push",
+            "/webhook/gh/ltest2",
+            pushevent,
+            { name: "ltest2" },
+            { subdir: "asd" },
+          ),
+          createContext(),
         ),
-        createContext(),
-      ),
-      {
-        body:
-          '{"success":false,"error":"provided sub directory is not valid as it does not end with a /"}',
-        headers: {
-          "content-type": "application/json",
+        {
+          body:
+            '{"success":false,"error":"provided sub directory is not valid as it does not end with a /"}',
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 400,
         },
-        statusCode: 400,
-      },
-    );
+      );
 
-    // Check that no versions.json file exists
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+      // Check that no versions.json file exists
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
-    // Check that no builds are queued
-    assertEquals(await database._builds.find({}), []);
+      // Check that no builds are queued
+      assertEquals(await database._builds.find({}), []);
 
-    // Check that there is no module entry in the database
-    assertEquals(await database.getModule("ltest2"), null);
+      // Check that there is no module entry in the database
+      assertEquals(await database.getModule("ltest2"), null);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event subdir success",
   async fn() {
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pushevent,
-        { name: "ltest2" },
-        { subdir: "asd/" },
-      ),
-      createContext(),
-    );
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pushevent,
+          { name: "ltest2" },
+          { subdir: "asd/" },
+        ),
+        createContext(),
+      );
 
-    const builds = await database._builds.find({});
+      const builds = await database._builds.find({});
 
-    // Check that a new build was queued
-    assertEquals(builds.length, 1);
-    assertEquals(
-      builds[0],
-      {
-        _id: builds[0]._id,
-        created_at: builds[0].created_at,
-        options: {
-          moduleName: "ltest2",
-          type: "github",
-          repository: "luca-rand/testing",
-          ref: "0.0.7",
-          version: "0.0.7",
-          subdir: "asd/",
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "0.0.7",
+            version: "0.0.7",
+            subdir: "asd/",
+          },
+          status: "queued",
         },
-        status: "queued",
-      },
-    );
+      );
 
-    assertEquals(resp, {
-      body:
-        `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-          builds[0]._id.$oid
-        }"}}`,
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 200,
-    });
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that no versions.json file was created
-    assertEquals(await getMeta("ltest2", "versions.json"), undefined);
-
-    // Clean up
-    await database._builds.deleteMany({});
-    await database._modules.deleteMany({});
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event already exists",
   async fn() {
-    await uploadMetaJson(
-      "ltest2",
-      "versions.json",
-      { latest: "0.0.7", versions: ["0.0.7"] },
-    );
+    try {
+      await uploadMetaJson(
+        "ltest2",
+        "versions.json",
+        { latest: "0.0.7", versions: ["0.0.7"] },
+      );
 
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pushevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body: '{"success":false,"error":"version already exists"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pushevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body: '{"success":false,"error":"version already exists"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
 
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
 
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Check that versions.json was not changed
-    assertEquals(
-      JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
-      { latest: "0.0.7", versions: ["0.0.7"] },
-    );
+      // Check that versions.json was not changed
+      assertEquals(
+        JSON.parse(decoder.decode(await getMeta("ltest2", "versions.json"))),
+        { latest: "0.0.7", versions: ["0.0.7"] },
+      );
 
-    // Check that no new build was queued
-    assertEquals(await database._builds.find({}), []);
-
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
+      // Check that no new build was queued
+      assertEquals(await database._builds.find({}), []);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });
 
 Deno.test({
   name: "push event already queued",
   async fn() {
-    await database.createBuild({
-      options: {
-        moduleName: "ltest2",
-        ref: "0.0.7",
-        repository: "luca-rand/testing",
+    try {
+      await database.createBuild({
+        options: {
+          moduleName: "ltest2",
+          ref: "0.0.7",
+          repository: "luca-rand/testing",
+          type: "github",
+          version: "0.0.7",
+        },
+        status: "queued",
+      });
+
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pushevent,
+          { name: "ltest2" },
+          {},
+        ),
+        createContext(),
+      );
+      assertEquals(resp, {
+        body:
+          '{"success":false,"error":"this module version is already being published"}',
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 400,
+      });
+
+      // Check that the database entry was created
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
+
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
         type: "github",
-        version: "0.0.7",
-      },
-      status: "queued",
-    });
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
 
-    // Send push event
-    const resp = await handler(
-      createJSONWebhookEvent(
-        "push",
-        "/webhook/gh/ltest2",
-        pushevent,
-        { name: "ltest2" },
-        {},
-      ),
-      createContext(),
-    );
-    assertEquals(resp, {
-      body:
-        '{"success":false,"error":"this module version is already being published"}',
-      headers: {
-        "content-type": "application/json",
-      },
-      statusCode: 400,
-    });
-
-    // Check that the database entry was created
-    const ltest2 = await database.getModule("ltest2");
-    assert(ltest2);
-    assert(ltest2.created_at <= new Date());
-    ltest2.created_at = new Date(2020, 1, 1);
-
-    // Check that the database entry
-    assertEquals(ltest2, {
-      name: "ltest2",
-      type: "github",
-      owner: "luca-rand",
-      repo: "testing",
-      description: "Move along, just for testing",
-      star_count: 2,
-      is_unlisted: false,
-      created_at: new Date(2020, 1, 1),
-    });
-
-    // Clean up
-    await s3.deleteObject("ltest2/meta/versions.json");
-    await database._modules.deleteMany({});
-    await database._builds.deleteMany({});
+      // Clean up
+      await s3.deleteObject("ltest2/meta/versions.json");
+    } finally {
+      await cleanupDatabase(database);
+      await s3.deleteObject("ltest2/meta/versions.json");
+    }
   },
 });

--- a/utils/test_utils.ts
+++ b/utils/test_utils.ts
@@ -1,5 +1,11 @@
 import type { ScheduledEvent } from "https://deno.land/x/lambda@1.4.0/types.d.ts";
-import type { APIGatewayProxyEventV2, SQSEvent, Context } from "../deps.ts";
+import type {
+  APIGatewayProxyEventV2,
+  SQSEvent,
+  Context,
+  S3Bucket,
+} from "../deps.ts";
+import type { Database } from "./database.ts";
 interface KV {
   [key: string]: string;
 }
@@ -147,4 +153,23 @@ export function createContext(): Context {
     getRemainingTimeInMillis: () => 0,
     succeed() {},
   };
+}
+
+export async function cleanupDatabase(db: Database): Promise<void> {
+  await Promise.all([
+    db._builds.deleteMany({}),
+    db._modules.deleteMany({}),
+    db._owner_quotas.deleteMany({}),
+  ]);
+}
+
+export async function cleanupStorage(
+  s: S3Bucket,
+  ...objects: string[]
+): Promise<void> {
+  const p = [];
+  for (let o of objects) {
+    p.push(s.deleteObject(o));
+  }
+  await Promise.all(p);
 }


### PR DESCRIPTION
moves all test functions into a try/finally statement where the finally block contains the cleanup steps.

tested by sprinkling assertion errors here and there and making sure they didn't cascade like they used to.

Fixes #144 