### PR TITLE
chore: add tests to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ package:
 	mkdir -p ./.terraform/tmp/stats/.deno_plugins && \
 	deno bundle --unstable ../api/stats.ts > ./.terraform/tmp/stats/bundle.js && \
 	cp ./.terraform/dl/deno_mongo_a79a4be6f465f12a177649c69941b66b.so ./.terraform/tmp/stats/.deno_plugins/
+
+test:
+	docker-compose up --build --abort-on-container-exit

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ You can then run `terraform destroy` to completely remove your staging environme
 To run tests locally, make sure you have Docker and docker-compose installed. Then run:
 
 ```sh
-docker-compose up --abort-on-container-exit --build
+make test
 ```


### PR DESCRIPTION
I got tired of running test via the long docker-compose command. Now it's as easy as `make test`.