### PR TITLE
chore: improve test cleanup

### DIFF
--- a/api/async/publish_test.ts
+++ b/api/async/publish_test.ts
@@ -313,20 +313,7 @@ Deno.test({
       assertEquals(readme?.body.length, 304);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest/meta/versions.json");
-      await s3.deleteObject("ltest/versions/0.0.9/meta/meta.json");
-      await s3.deleteObject("ltest/versions/0.0.9/meta/deps_v2.json");
-      await s3.deleteObject(
-        "ltest/versions/0.0.9/raw/.github/workflows/ci.yml",
-      );
-      await s3.deleteObject("ltest/versions/0.0.9/raw/.vscode/settings.json");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/LICENCE");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/deps.ts");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/fixtures/%");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/mod.ts");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/mod_test.md");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/subproject/README.md");
-      await s3.deleteObject("ltest/versions/0.0.9/raw/subproject/mod.ts");
+      await s3.empty();
     }
   },
 });
@@ -435,10 +422,7 @@ Deno.test({
       assertEquals(readme?.body.length, 354);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest/meta/versions.json");
-      await s3.deleteObject("ltest/versions/0.0.7/meta/meta.json");
-      await s3.deleteObject("ltest/versions/0.0.7/raw/mod.ts");
-      await s3.deleteObject("ltest/versions/0.0.7/raw/README.md");
+      await s3.empty();
     }
   },
 });

--- a/api/async/stargazers_test.ts
+++ b/api/async/stargazers_test.ts
@@ -8,6 +8,7 @@ import { handler } from "./stargazers.ts";
 import { Database, Module } from "../../utils/database.ts";
 import { GitHub } from "../../utils/github.ts";
 import { assertEquals } from "https://deno.land/std@0.69.0/testing/asserts.ts";
+import { s3 } from "../../utils/storage.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
 const gh = new GitHub();
@@ -51,6 +52,7 @@ Deno.test({
       assertEquals(updated?.created_at, ltest.created_at);
     } finally {
       await cleanupDatabase(database);
+      await s3.empty();
     }
   },
 });

--- a/api/builds/get_test.ts
+++ b/api/builds/get_test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../utils/test_utils.ts";
 import { assertEquals } from "../../test_deps.ts";
 import { Database } from "../../utils/database.ts";
+import { s3 } from "../../utils/storage.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
 
@@ -48,6 +49,7 @@ Deno.test({
       await database._builds.deleteMany({});
     } finally {
       await cleanupDatabase(database);
+      await s3.empty();
     }
   },
 });

--- a/api/webhook/github_create_test.ts
+++ b/api/webhook/github_create_test.ts
@@ -96,7 +96,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest-2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -134,7 +134,7 @@ Deno.test({
       assertEquals(await database.getModule("frisbee"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("frisbee/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -206,10 +206,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
-      await s3.deleteObject("ltest3/meta/versions.json");
-      await s3.deleteObject("ltest4/meta/versions.json");
-      await s3.deleteObject("ltest5/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -266,22 +263,7 @@ Deno.test({
       await database._modules.deleteMany({});
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
-      await s3.deleteObject("ltest3/meta/versions.json");
-      await s3.deleteObject("ltest4/meta/versions.json");
-      await s3.deleteObject("ltest5/meta/versions.json");
-      await s3.deleteObject("ltest6/meta/versions.json");
-      await s3.deleteObject("ltest7/meta/versions.json");
-      await s3.deleteObject("ltest8/meta/versions.json");
-      await s3.deleteObject("ltest9/meta/versions.json");
-      await s3.deleteObject("ltest10/meta/versions.json");
-      await s3.deleteObject("ltest11/meta/versions.json");
-      await s3.deleteObject("ltest12/meta/versions.json");
-      await s3.deleteObject("ltest13/meta/versions.json");
-      await s3.deleteObject("ltest14/meta/versions.json");
-      await s3.deleteObject("ltest15/meta/versions.json");
-      await s3.deleteObject("ltest16/meta/versions.json");
-      await s3.deleteObject("ltest17/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -341,14 +323,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
-      await s3.deleteObject("ltest3/meta/versions.json");
-      await s3.deleteObject("ltest4/meta/versions.json");
-      await s3.deleteObject("ltest5/meta/versions.json");
-      await s3.deleteObject("ltest6/meta/versions.json");
-      await s3.deleteObject("ltest7/meta/versions.json");
-      await s3.deleteObject("ltest8/meta/versions.json");
-      await s3.deleteObject("ltest9/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -421,7 +396,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -494,7 +469,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -532,7 +507,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -571,7 +546,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -644,7 +619,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -707,7 +682,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -781,7 +756,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -840,13 +815,9 @@ Deno.test({
 
       // Check that no new build was queued
       assertEquals(await database._builds.find({}), []);
-
-      // Clean up
-      await s3.deleteObject("ltest2/meta/versions.json");
-      await database._modules.deleteMany({});
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -903,12 +874,9 @@ Deno.test({
         is_unlisted: false,
         created_at: new Date(2020, 1, 1),
       });
-
-      // Clean up
-      await s3.deleteObject("ltest2/meta/versions.json");
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });

--- a/api/webhook/github_ping_test.ts
+++ b/api/webhook/github_ping_test.ts
@@ -58,7 +58,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest-2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -96,7 +96,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest-2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -134,7 +134,7 @@ Deno.test({
       assertEquals(await database.getModule("frisbee"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -190,7 +190,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -246,7 +246,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -318,10 +318,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
-      await s3.deleteObject("ltest3/meta/versions.json");
-      await s3.deleteObject("ltest4/meta/versions.json");
-      await s3.deleteObject("ltest5/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -386,7 +383,7 @@ Deno.test({
       });
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -453,7 +450,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });

--- a/api/webhook/github_push_test.ts
+++ b/api/webhook/github_push_test.ts
@@ -92,7 +92,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest-2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -130,7 +130,7 @@ Deno.test({
       assertEquals(await database.getModule("frisbee"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("frisbee/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -202,10 +202,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
-      await s3.deleteObject("ltest3/meta/versions.json");
-      await s3.deleteObject("ltest4/meta/versions.json");
-      await s3.deleteObject("ltest5/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -278,7 +275,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -316,7 +313,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -355,7 +352,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -428,7 +425,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -491,7 +488,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest2"), null);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -565,7 +562,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -626,7 +623,7 @@ Deno.test({
       assertEquals(await database._builds.find({}), []);
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });
@@ -683,12 +680,9 @@ Deno.test({
         is_unlisted: false,
         created_at: new Date(2020, 1, 1),
       });
-
-      // Clean up
-      await s3.deleteObject("ltest2/meta/versions.json");
     } finally {
       await cleanupDatabase(database);
-      await s3.deleteObject("ltest2/meta/versions.json");
+      await s3.empty();
     }
   },
 });

--- a/deps.ts
+++ b/deps.ts
@@ -17,7 +17,7 @@ export {
   MongoClient,
   ObjectId,
 } from "https://raw.githubusercontent.com/lucacasonato/deno_mongo_lambda/v0.12.1/mod.ts";
-export { S3Bucket } from "https://deno.land/x/s3@0.1.3/mod.ts";
+export { S3Bucket } from "https://deno.land/x/s3@0.2.0/mod.ts";
 export { SQSQueue } from "https://deno.land/x/sqs@0.3.4/mod.ts";
 export { SSM } from "https://deno.land/x/ssm@0.1.2/mod.ts";
 export { lookup } from "https://deno.land/x/media_types@v2.4.7/mod.ts";


### PR DESCRIPTION
Upgrade the s3 dependency to v0.2.0 to benefit from the addition
of the `empty` method. This way we can more easily cleanup after
tests without having to know exactly how many objects are created
in the s3 bucket and what their keys are.