### PR TITLE
chore: refactor webhook function

### DIFF
--- a/api/webhook/github_push_test.ts
+++ b/api/webhook/github_push_test.ts
@@ -913,3 +913,159 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "push event at max registered to repository",
+  async fn() {
+    try {
+      await database.saveModule({
+        name: "ltest2",
+        type: "github",
+        repo_id: 274939732,
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest3",
+        type: "github",
+        repo_id: 274939732,
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+      await database.saveModule({
+        name: "ltest4",
+        type: "github",
+        repo_id: 274939732,
+        owner: "luca-rand",
+        repo: "testing",
+        description: "",
+        star_count: 4,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+
+      const res = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/lest4",
+          pushevent,
+          { name: "ltest4" },
+          {},
+        ),
+        createContext(),
+      );
+
+      const builds = await database._builds.find({});
+
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest4",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
+        },
+      );
+
+      // Send push event for ltest5
+      assertEquals(
+        res,
+        {
+          body:
+            `{"success":true,"data":{"module":"ltest4","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+              builds[0]._id.$oid
+            }"}}`,
+          headers: {
+            "content-type": "application/json",
+          },
+          statusCode: 200,
+        },
+      );
+    } finally {
+      await cleanupDatabase(database);
+      await s3.empty();
+    }
+  },
+});
+
+Deno.test({
+  name: "push event grandfathered forbidden name",
+  async fn() {
+    try {
+      // grandfathered module with a forbidden name
+      await database.saveModule({
+        name: "frisbee",
+        description: "Move along, just for frisbee",
+        repo_id: 274939732,
+        owner: "luca-rand",
+        repo: "frisbee",
+        star_count: 4,
+        type: "github",
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/frisbee",
+          pusheventforbidden,
+          { name: "frisbee" },
+          {},
+        ),
+        createContext(),
+      );
+
+      const builds = await database._builds.find({});
+
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "frisbee",
+            type: "github",
+            repository: "luca-rand/frisbee",
+            ref: "0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
+        },
+      );
+
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"frisbee","version":"0.0.7","repository":"luca-rand/frisbee","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
+    } finally {
+      await cleanupDatabase(database);
+      await s3.empty();
+    }
+  },
+});


### PR DESCRIPTION
First pass at cleaning up the webhook function handler. I haven't changed the general flow of the code, mostly worked in the `checkAvailable` and `initiateBuild` functions since I felt they were the hardest to navigate.

---

Adds new interface for webhook handler functions. Also adds jsdoc
comments for each event, based on [this
docs](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/github-event-types).

bring checkBlocked return value into its own function

move check for repo id into its own function

move the check for number of modules per repo into its own function.

move the owner quota check into its own function

move module name validation into its own function

first pass at simplifying codeflow of check available function

remove check for `!entry` as it has no impact on tests

simplify check available function to a single return statement

move some functions around to make it easier to follow from top to bottom

move version validation to its own function

rename check available function to a more descriptive name

add jsdoc comments to the validation functions to explain their purpose

move subdir pattern verification to its own function

move module-level constants closer to where they are being used