### PR TITLE
add type definitions for the different API reponse body

### DIFF
--- a/api/async/stargazers.ts
+++ b/api/async/stargazers.ts
@@ -8,7 +8,6 @@
 
 import type { Context, ScheduledEvent } from "../../deps.ts";
 import { SSM } from "../../deps.ts";
-import type { ScoredModule, SearchResult } from "../../utils/database.ts";
 import { Database, Module } from "../../utils/database.ts";
 import { GitHub, GitHubAuth } from "../../utils/github.ts";
 

--- a/api/builds/get.ts
+++ b/api/builds/get.ts
@@ -13,6 +13,10 @@ import type {
 import { ObjectId } from "../../deps.ts";
 import { respondJSON } from "../../utils/http.ts";
 import { Database } from "../../utils/database.ts";
+import type {
+  APIBuildGetResponseSuccess,
+  APIErrorResponse,
+} from "../../utils/types.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
 
@@ -25,7 +29,9 @@ export async function handler(
   if (!id) {
     return respondJSON({
       statusCode: 400,
-      body: JSON.stringify({ success: false, error: "no build id provided" }),
+      body: JSON.stringify(
+        { success: false, error: "no build id provided" } as APIErrorResponse,
+      ),
     });
   }
 
@@ -34,7 +40,9 @@ export async function handler(
   } catch (err) {
     return respondJSON({
       statusCode: 400,
-      body: JSON.stringify({ success: false, error: "invalid build id" }),
+      body: JSON.stringify(
+        { success: false, error: "invalid build id" } as APIErrorResponse,
+      ),
     });
   }
 
@@ -43,12 +51,16 @@ export async function handler(
   if (build === null) {
     return respondJSON({
       statusCode: 404,
-      body: JSON.stringify({ success: false, error: "build not found" }),
+      body: JSON.stringify(
+        { success: false, error: "build not found" } as APIErrorResponse,
+      ),
     });
   }
 
   return respondJSON({
     statusCode: 200,
-    body: JSON.stringify({ success: true, data: { build } }),
+    body: JSON.stringify(
+      { success: true, data: { build } } as APIBuildGetResponseSuccess,
+    ),
   });
 }

--- a/api/modules/get.ts
+++ b/api/modules/get.ts
@@ -13,6 +13,10 @@ import type {
 } from "../../deps.ts";
 import { respondJSON } from "../../utils/http.ts";
 import { Database } from "../../utils/database.ts";
+import type {
+  APIErrorResponse,
+  APIModuleGetResponse,
+} from "../../utils/types.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
 
@@ -28,7 +32,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: "no module name specified",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -38,7 +42,9 @@ export async function handler(
     return respondJSON(
       {
         statusCode: 404,
-        body: JSON.stringify({ success: false, error: "module not found" }),
+        body: JSON.stringify(
+          { success: false, error: "module not found" } as APIErrorResponse,
+        ),
       },
     );
   }
@@ -52,6 +58,6 @@ export async function handler(
         description: module.description,
         star_count: module.star_count,
       },
-    }),
+    } as APIModuleGetResponse),
   });
 }

--- a/api/modules/list.ts
+++ b/api/modules/list.ts
@@ -22,6 +22,11 @@ import {
   SortValues,
 } from "../../utils/database.ts";
 import type { ScoredModule } from "../../utils/database.ts";
+import type {
+  APIErrorResponse,
+  APIModuleListResponseSuccess,
+  APIModuleListShortResponse,
+} from "../../utils/types.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
 
@@ -34,7 +39,7 @@ export async function handler(
     const results = await database.listAllModuleNames();
     return respondJSON({
       statusCode: 200,
-      body: JSON.stringify(results),
+      body: JSON.stringify(results as APIModuleListShortResponse),
       headers: {
         "cache-control": "max-age=60, must-revalidate",
       },
@@ -52,7 +57,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: "the limit may not be larger than 100 or smaller than 1",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -62,7 +67,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: "the page number must not be lower than 1",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -73,7 +78,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: `the sort order must be one of ${publicSort.join(", ")}`,
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -101,6 +106,6 @@ export async function handler(
     body: JSON.stringify({
       success: true,
       data: { total_count: count, options, results },
-    }),
+    } as APIModuleListResponseSuccess),
   });
 }

--- a/api/stats.ts
+++ b/api/stats.ts
@@ -12,6 +12,7 @@ import type {
 } from "../deps.ts";
 import { respondJSON } from "../utils/http.ts";
 import { Database } from "../utils/database.ts";
+import type { APIStatsResponse } from "../utils/types.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
 
@@ -35,6 +36,6 @@ export async function handler(
         recently_added_modules,
         recently_uploaded_versions,
       },
-    }),
+    } as APIStatsResponse),
   });
 }

--- a/api/webhook/github.ts
+++ b/api/webhook/github.ts
@@ -27,7 +27,12 @@ import type {
 } from "../../utils/webhooks.d.ts";
 import { isIp4InCidrs } from "../../utils/net.ts";
 import { queueBuild } from "../../utils/queue.ts";
-import type { VersionInfo } from "../../utils/types.ts";
+import type {
+  APIErrorResponse,
+  APIInfoResponse,
+  APIWebhookResponseSuccess,
+  VersionInfo,
+} from "../../utils/types.ts";
 import { isForbidden } from "../../utils/moderation.ts";
 
 interface WebhookEvent {
@@ -50,7 +55,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: "request does not come from GitHub",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -61,7 +66,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: "no module name specified",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -78,7 +83,7 @@ export async function handler(
       body: JSON.stringify({
         success: false,
         error: "content-type is not json or x-www-form-urlencoded",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -101,7 +106,7 @@ export async function handler(
         body: JSON.stringify({
           success: false,
           info: "not a ping, or create event",
-        }),
+        } as APIInfoResponse),
       });
   }
 }
@@ -121,7 +126,7 @@ async function pingEvent(
       body: JSON.stringify({
         success: false,
         error: "no body provided",
-      }),
+      } as APIErrorResponse),
     });
   }
   const webhook = JSON.parse(event.body) as WebhookPayloadPing;
@@ -178,7 +183,7 @@ async function pingEvent(
         module: moduleName,
         repository: `${owner}/${repo}`,
       },
-    }),
+    } as APIWebhookResponseSuccess),
   });
 }
 
@@ -195,7 +200,7 @@ async function pushEvent(
       body: JSON.stringify({
         success: false,
         error: "no body provided",
-      }),
+      } as APIErrorResponse),
     });
   }
   const webhook = JSON.parse(event.body) as WebhookPayloadPush;
@@ -208,7 +213,7 @@ async function pushEvent(
       body: JSON.stringify({
         success: false,
         info: "created ref is not tag",
-      }),
+      } as APIInfoResponse),
     });
   }
 
@@ -249,7 +254,7 @@ async function createEvent(
       body: JSON.stringify({
         success: false,
         error: "no body provided",
-      }),
+      } as APIErrorResponse),
     });
   }
   const webhook = JSON.parse(event.body) as WebhookPayloadCreate;
@@ -263,7 +268,7 @@ async function createEvent(
       body: JSON.stringify({
         success: false,
         info: "created ref is not tag",
-      }),
+      } as APIInfoResponse),
     });
   }
 
@@ -322,7 +327,7 @@ async function initiateBuild(
       body: JSON.stringify({
         success: false,
         info: "ignoring event as the version does not match the version prefix",
-      }),
+      } as APIInfoResponse),
     });
   }
 
@@ -382,7 +387,7 @@ async function initiateBuild(
         repository: `${owner}/${repo}`,
         status_url: `https://deno.land/status/${buildID}`,
       },
-    }),
+    } as APIWebhookResponseSuccess),
   });
 }
 
@@ -428,7 +433,7 @@ function checkSubdir(
         body: JSON.stringify({
           success: false,
           error: "provided sub directory is not valid as it starts with a /",
-        }),
+        } as APIErrorResponse),
       });
     } else if (!subdir.endsWith("/")) {
       return respondJSON({
@@ -437,7 +442,7 @@ function checkSubdir(
           success: false,
           error:
             "provided sub directory is not valid as it does not end with a /",
-        }),
+        } as APIErrorResponse),
       });
     }
   }
@@ -454,7 +459,7 @@ async function checkBlocked(
       body: JSON.stringify({
         success: false,
         error: `Publishing your module failed. Please contact ry@deno.land.`,
-      }),
+      } as APIErrorResponse),
     });
   }
   return;
@@ -472,7 +477,7 @@ function checkMatchesRepo(
       body: JSON.stringify({
         success: false,
         error: "module name is registered to a different repository",
-      }),
+      } as APIErrorResponse),
     });
   }
   return;
@@ -495,7 +500,7 @@ async function checkModulesInRepo(
         success: false,
         error:
           `Max number of modules for one repository (${MAX_MODULES_PER_REPOSITORY}) has been reached. Please contact ry@deno.land if you need more.`,
-      }),
+      } as APIErrorResponse),
     });
   }
   return;
@@ -517,7 +522,7 @@ async function hasReachedQuota(
         success: false,
         error:
           `Max number of modules for one user/org (${maxModuleQuota}) has been reached. Please contact ry@deno.land if you need more.`,
-      }),
+      } as APIErrorResponse),
     });
   }
   return;
@@ -536,7 +541,7 @@ async function checkName(
         body: JSON.stringify({
           success: false,
           error: "module name is not valid",
-        }),
+        } as APIErrorResponse),
       });
     }
 
@@ -549,7 +554,7 @@ async function checkName(
         body: JSON.stringify({
           success: false,
           error: "found forbidden word in module name",
-        }),
+        } as APIErrorResponse),
       });
     }
   }
@@ -582,7 +587,7 @@ async function checkVersion(
       body: JSON.stringify({
         success: false,
         error: "version already exists",
-      }),
+      } as APIErrorResponse),
     });
   }
 
@@ -594,7 +599,7 @@ async function checkVersion(
       body: JSON.stringify({
         success: false,
         error: "this module version is already being published",
-      }),
+      } as APIErrorResponse),
     });
   }
   return;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,3 +1,75 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+
+import {
+  Build,
+  RecentlyAddedModuleResult,
+  RecentlyAddedUploadedVersions,
+  SearchOptions,
+  SearchResult,
+} from "../utils/database.ts";
+
+export type APIResponseBase = {
+  success: boolean;
+};
+
+export type APIErrorResponse = APIResponseBase & { error: string };
+export type APIInfoResponse = APIResponseBase & { info: string };
+
+export type APIStatsResponse = APIResponseBase & {
+  data: {
+    total_count: number;
+    total_versions: number;
+    recently_added_modules: RecentlyAddedModuleResult[];
+    recently_uploaded_versions: RecentlyAddedUploadedVersions[];
+  };
+};
+
+export type APIWebhookResponse =
+  | APIWebhookResponseSuccess
+  | APIInfoResponse
+  | APIErrorResponse;
+
+export type APIWebhookResponseSuccess = APIResponseBase & {
+  data: {
+    module: string;
+    repository: string;
+    version?: string;
+    status_url?: string;
+  };
+};
+
+export type APIModuleGetResponse = APIResponseBase & {
+  data: {
+    name: string;
+    description: string;
+    star_count: number;
+  };
+};
+
+export type APIModuleListShortResponse = string[];
+
+export type APIModuleListResponse =
+  | APIErrorResponse
+  | APIModuleListResponseSuccess;
+
+export type APIModuleListResponseSuccess = APIResponseBase & {
+  data: {
+    total_count: number;
+    options: SearchOptions;
+    results: SearchResult[];
+  };
+};
+
+export type APIBuildGetResponse =
+  | APIErrorResponse
+  | APIBuildGetResponseSuccess;
+
+export type APIBuildGetResponseSuccess = APIResponseBase & {
+  data: {
+    build: Build;
+  };
+};
+
 export interface DirectoryListingFile {
   path: string;
   size: number | undefined;


### PR DESCRIPTION
Fixes #173 may not be worth registering a module just for the types, but at least now they will be available on doc.deno.land

Here's what it looks like on [doc.deno.land](https://doc.deno.land/https/raw.githubusercontent.com/wperron/deno_registry2/feat/api-types/utils/types.ts)