### PR TITLE
feat: add keep_version_prefix option

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ The contents and headers should be a GitHub `create` or `push` webhook event. Mo
 There are optional query parameters that can change the behavior of the request:
 
 - `subdir`: this specifies a subdirectory of the repository to upload (not set by default). This directory must be in the format `std/` (notice the trailing slash.)
-- `version_prefix`: only upload versions that match this prefix. When this is set to `std/` and you tag version `std/0.63.0`, version `0.63.0` will be uploaded.
+- `version_prefix_filter`: only upload versions that match this prefix. When this is set to `std/` and you tag version `std/0.63.0`, version `0.63.0` will be uploaded. You can a `keep_version_prefix=true` query parameter to retain the version prefix for publishing (`std/0.63.0` would be published as `std/0.63.0`).
 
 ### Response
 
@@ -59,7 +59,7 @@ OR
 ```json
 {
   "success": false,
-  "error": "module name is registered to a different repository",
+  "error": "module name is registered to a different repository"
 }
 ```
 

--- a/api/async/stargazers_test.ts
+++ b/api/async/stargazers_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "../../test_deps.ts";
+import { assert, assertEquals } from "../../test_deps.ts";
 import {
   cleanupDatabase,
   createContext,
@@ -7,7 +7,6 @@ import {
 import { handler } from "./stargazers.ts";
 import { Database, Module } from "../../utils/database.ts";
 import { GitHub } from "../../utils/github.ts";
-import { assertEquals } from "https://deno.land/std@0.69.0/testing/asserts.ts";
 import { s3 } from "../../utils/storage.ts";
 
 const database = new Database(Deno.env.get("MONGO_URI")!);
@@ -16,24 +15,32 @@ const gh = new GitHub();
 const ltest: Module = {
   name: "ltest",
   description: "Testing all the things!",
+  // deno-lint-ignore camelcase
   repo_id: 274939732,
   type: "github",
   owner: "luca-rand",
   repo: "testing",
+  // deno-lint-ignore camelcase
   star_count: 0, // real number is 2 atm
+  // deno-lint-ignore camelcase
   is_unlisted: false,
+  // deno-lint-ignore camelcase
   created_at: new Date(2020, 1, 1),
 };
 
 const utest: Module = {
   name: "unlisted_module",
   description: "Testing all the things! -- unlisted",
+  // deno-lint-ignore camelcase
   repo_id: 70289105,
   type: "github",
   owner: "wperron",
   repo: "testing",
+  // deno-lint-ignore camelcase
   star_count: 0,
+  // deno-lint-ignore camelcase
   is_unlisted: true,
+  // deno-lint-ignore camelcase
   created_at: new Date(2020, 1, 1),
 };
 

--- a/api/stats.ts
+++ b/api/stats.ts
@@ -19,10 +19,10 @@ export async function handler(
   event: APIGatewayProxyEventV2,
   context: Context,
 ): Promise<APIGatewayProxyResultV2> {
-  const total_count = await database.countModules();
-  const total_versions = await database.countAllVersions();
-  const recently_added_modules = await database.listRecentlyAddedModules();
-  const recently_uploaded_versions = await database
+  const totalCount = await database.countModules();
+  const totalVersions = await database.countAllVersions();
+  const recentlyAddedModules = await database.listRecentlyAddedModules();
+  const recentlyUploadedVersions = await database
     .listRecentlyUploadedVersions();
 
   return respondJSON({
@@ -30,10 +30,10 @@ export async function handler(
     body: JSON.stringify({
       success: true,
       data: {
-        total_count,
-        total_versions,
-        recently_added_modules,
-        recently_uploaded_versions,
+        total_count: totalCount,
+        total_versions: totalVersions,
+        recently_added_modules: recentlyAddedModules,
+        recently_uploaded_versions: recentlyUploadedVersions,
       },
     }),
   });

--- a/api/webhook/github_ping_test.ts
+++ b/api/webhook/github_ping_test.ts
@@ -332,12 +332,12 @@ Deno.test({
   name: "ping event rename repository",
   async fn() {
     try {
-      const repo_id = 274939732;
+      const repoId = 274939732;
 
       await database.saveModule({
         name: "ltest",
         description: "testing things",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing-oldname",
         star_count: 4,
@@ -368,7 +368,7 @@ Deno.test({
 
       const ltest2 = await database.getModule("ltest");
       assert(ltest2);
-      assertEquals(ltest2.repo_id, repo_id);
+      assertEquals(ltest2.repo_id, repoId);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -380,12 +380,12 @@ Deno.test({
   name: "ping event wrong repository",
   async fn() {
     try {
-      const repo_id = 123456789;
+      const repoId = 123456789;
 
       database.saveModule({
         name: "ltest",
         description: "testing things",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing2",
         star_count: 4,
@@ -430,7 +430,7 @@ Deno.test({
       assertEquals(ltest, {
         name: "ltest",
         description: "testing things",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing2",
         star_count: 4,

--- a/api/webhook/github_push_test.ts
+++ b/api/webhook/github_push_test.ts
@@ -333,7 +333,7 @@ Deno.test({
           "/webhook/gh/ltest2",
           pushevent,
           { name: "ltest2" },
-          { version_prefix: "v" },
+          { version_prefix_filter: "v" },
         ),
         createContext(),
       );
@@ -363,6 +363,154 @@ Deno.test({
 
 Deno.test({
   name: "push event version prefix match",
+  async fn() {
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pusheventVersionPrefix,
+          { name: "ltest2" },
+          { version_prefix_filter: "v" },
+        ),
+        createContext(),
+      );
+
+      const builds = await database._builds.find({});
+
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "v0.0.7",
+            version: "0.0.7",
+          },
+          status: "queued",
+        },
+      );
+
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
+
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
+
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        repo_id: 274939732,
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.empty();
+    }
+  },
+});
+
+Deno.test({
+  name: "push event version prefix match and keep",
+  async fn() {
+    try {
+      // Send push event
+      const resp = await handler(
+        createJSONWebhookEvent(
+          "push",
+          "/webhook/gh/ltest2",
+          pusheventVersionPrefix,
+          { name: "ltest2" },
+          { version_prefix_filter: "v", keep_version_prefix: "true" },
+        ),
+        createContext(),
+      );
+
+      const builds = await database._builds.find({});
+
+      // Check that a new build was queued
+      assertEquals(builds.length, 1);
+      assertEquals(
+        builds[0],
+        {
+          _id: builds[0]._id,
+          created_at: builds[0].created_at,
+          options: {
+            moduleName: "ltest2",
+            type: "github",
+            repository: "luca-rand/testing",
+            ref: "v0.0.7",
+            version: "v0.0.7",
+          },
+          status: "queued",
+        },
+      );
+
+      assertEquals(resp, {
+        body:
+          `{"success":true,"data":{"module":"ltest2","version":"v0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
+            builds[0]._id.$oid
+          }"}}`,
+        headers: {
+          "content-type": "application/json",
+        },
+        statusCode: 200,
+      });
+
+      const ltest2 = await database.getModule("ltest2");
+      assert(ltest2);
+      assert(ltest2.created_at <= new Date());
+      ltest2.created_at = new Date(2020, 1, 1);
+
+      // Check that the database entry
+      assertEquals(ltest2, {
+        name: "ltest2",
+        type: "github",
+        repo_id: 274939732,
+        owner: "luca-rand",
+        repo: "testing",
+        description: "Move along, just for testing",
+        star_count: 2,
+        is_unlisted: false,
+        created_at: new Date(2020, 1, 1),
+      });
+
+      // Check that no versions.json file was created
+      assertEquals(await getMeta("ltest2", "versions.json"), undefined);
+    } finally {
+      await cleanupDatabase(database);
+      await s3.empty();
+    }
+  },
+});
+
+Deno.test({
+  name: "push event version prefix match legacy",
   async fn() {
     try {
       // Send push event
@@ -797,12 +945,12 @@ Deno.test({
   name: "push event rename repository",
   async fn() {
     try {
-      const repo_id = 274939732;
+      const repoId = 274939732;
 
       await database.saveModule({
         name: "ltest",
         description: "testing things",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing-oldname",
         star_count: 4,
@@ -870,12 +1018,12 @@ Deno.test({
         { latest: "0.0.7", versions: ["0.0.7"] },
       );
 
-      const repo_id = 274939732;
+      const repoId = 274939732;
 
       await database.saveModule({
         name: "ltest",
         description: "testing things",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing-oldname",
         star_count: 4,
@@ -913,7 +1061,7 @@ Deno.test({
       assertEquals(ltest, {
         name: "ltest",
         type: "github",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing",
         description: "Move along, just for testing",
@@ -952,12 +1100,12 @@ Deno.test({
         status: "queued",
       });
 
-      const repo_id = 274939732;
+      const repoId = 274939732;
 
       await database.saveModule({
         name: "ltest",
         description: "testing things",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing-oldname",
         star_count: 4,
@@ -997,7 +1145,7 @@ Deno.test({
       assertEquals(ltest, {
         name: "ltest",
         type: "github",
-        repo_id: repo_id,
+        repo_id: repoId,
         owner: "luca-rand",
         repo: "testing",
         description: "Move along, just for testing",

--- a/utils/database.ts
+++ b/utils/database.ts
@@ -40,6 +40,7 @@ const sort = {
   newest: { "created_at": -1 },
   oldest: { "created_at": 1 },
   random: null,
+  // deno-lint-ignore camelcase
   search_order: null,
 };
 
@@ -281,9 +282,9 @@ export class Database {
   }
 
   async countModulesForRepository(
-    repo_id: number,
+    repoId: number,
   ): Promise<number> {
-    const modules = await this._modules.find({ repo_id });
+    const modules = await this._modules.find({ repo_id: repoId });
     return modules.length;
   }
 

--- a/utils/database_test.ts
+++ b/utils/database_test.ts
@@ -13,11 +13,15 @@ const ltest: Module = {
   name: "ltest",
   description: "Testing all the things!",
   type: "github",
+  // deno-lint-ignore camelcase
   repo_id: 123,
   owner: "luca-rand",
   repo: "testing",
+  // deno-lint-ignore camelcase
   star_count: 5,
+  // deno-lint-ignore camelcase
   is_unlisted: false,
+  // deno-lint-ignore camelcase
   created_at: new Date(2020, 1, 1),
 };
 
@@ -25,11 +29,15 @@ const utest: Module = {
   name: "unlisted_module",
   description: "Testing all the things! -- unlisted",
   type: "github",
+  // deno-lint-ignore camelcase
   repo_id: 124,
   owner: "wperron",
   repo: "testing-unlisted",
+  // deno-lint-ignore camelcase
   star_count: 5,
+  // deno-lint-ignore camelcase
   is_unlisted: true,
+  // deno-lint-ignore camelcase
   created_at: new Date(2020, 1, 1),
 };
 
@@ -68,6 +76,7 @@ Deno.test({
     assertEquals(await database.countModules(), 1);
     assertEquals(await database.getModule(ltest.name), ltest);
 
+    // deno-lint-ignore camelcase
     const ltestWith6Stars = { ...ltest, star_count: 6 };
 
     await database.saveModule(ltestWith6Stars);
@@ -164,7 +173,9 @@ Deno.test({
 const ownerQuota1: OwnerQuota = {
   owner: "luca-rand",
   type: "github",
+  // deno-lint-ignore camelcase
   max_modules: 5,
+  // deno-lint-ignore camelcase
   max_total_size: undefined,
   blocked: false,
 };


### PR DESCRIPTION
This will finally let us use the GH Webhook for publishing deno.land/x/deno. Also does some lint cleanup in preparation for upcoming Deno upgrade.