### PR TITLE
chore: update to amazonlinux2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 download:
 	cd terraform/ && \
 	mkdir -p ./.terraform/dl && \
-	curl -L https://github.com/hayd/deno-lambda/releases/download/1.5.2/deno-lambda-layer.zip > ./.terraform/dl/deno-lambda-layer.zip && \
+	curl -L https://github.com/hayd/deno-lambda/files/5578463/deno-lambda-layer.zip > ./.terraform/dl/deno-lambda-layer.zip && \
 	curl -L https://github.com/lucacasonato/deno_mongo_lambda/releases/download/v0.12.1/libdeno_mongo.so > ./.terraform/dl/deno_mongo_a79a4be6f465f12a177649c69941b66b.so
 
 package:

--- a/terraform/builds.tf
+++ b/terraform/builds.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "builds_get" {
 
   source_code_hash = filebase64sha256(data.archive_file.builds_get_zip.output_path)
 
-  runtime = "provided"
+  runtime = "provided.al2"
   layers  = [aws_lambda_layer_version.deno_layer.arn]
 
   timeout     = local.lambda_default_timeout

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,9 +14,10 @@ locals {
 }
 
 resource "aws_lambda_layer_version" "deno_layer" {
-  filename         = "${path.module}/.terraform/dl/deno-lambda-layer.zip"
-  layer_name       = "${local.prefix}-deno-${local.short_uuid}"
-  source_code_hash = filebase64sha256("${path.module}/.terraform/dl/deno-lambda-layer.zip")
+  filename            = "${path.module}/.terraform/dl/deno-lambda-layer.zip"
+  layer_name          = "${local.prefix}-deno-${local.short_uuid}"
+  source_code_hash    = filebase64sha256("${path.module}/.terraform/dl/deno-lambda-layer.zip")
+  compatible_runtimes = ["provided.al2"]
 }
 
 resource "aws_s3_bucket" "storage_bucket" {

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "modules_get" {
 
   source_code_hash = filebase64sha256(data.archive_file.modules_get_zip.output_path)
 
-  runtime = "provided"
+  runtime = "provided.al2"
   layers  = [aws_lambda_layer_version.deno_layer.arn]
 
   timeout     = local.lambda_default_timeout
@@ -71,7 +71,7 @@ resource "aws_lambda_function" "modules_list" {
 
   source_code_hash = filebase64sha256(data.archive_file.modules_list_zip.output_path)
 
-  runtime = "provided"
+  runtime = "provided.al2"
   layers  = [aws_lambda_layer_version.deno_layer.arn]
 
   timeout     = local.lambda_default_timeout

--- a/terraform/publish.tf
+++ b/terraform/publish.tf
@@ -13,8 +13,8 @@ resource "aws_lambda_function" "async_publish" {
 
   source_code_hash = filebase64sha256(data.archive_file.async_publish_zip.output_path)
 
-  runtime = "provided"
-  layers  = [aws_lambda_layer_version.deno_layer.arn, "arn:aws:lambda:${var.region}:553035198032:layer:git-lambda2:6"]
+  runtime = "provided.al2"
+  layers  = [aws_lambda_layer_version.deno_layer.arn, "arn:aws:lambda:${var.region}:553035198032:layer:git-lambda2:8"]
 
   timeout     = 300
   memory_size = 1024

--- a/terraform/stargazers.tf
+++ b/terraform/stargazers.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "stargazers" {
 
   source_code_hash = filebase64sha256(data.archive_file.stargazers_zip.output_path)
 
-  runtime = "provided"
+  runtime = "provided.al2"
   layers  = [aws_lambda_layer_version.deno_layer.arn]
 
   timeout     = 300

--- a/terraform/stats.tf
+++ b/terraform/stats.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "stats" {
 
   source_code_hash = filebase64sha256(data.archive_file.stats_zip.output_path)
 
-  runtime = "provided"
+  runtime = "provided.al2"
   layers  = [aws_lambda_layer_version.deno_layer.arn]
 
   timeout     = 10

--- a/terraform/webhook.tf
+++ b/terraform/webhook.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "webhook_github" {
 
   source_code_hash = filebase64sha256(data.archive_file.webhook_github_zip.output_path)
 
-  runtime = "provided"
+  runtime = "provided.al2"
   layers  = [aws_lambda_layer_version.deno_layer.arn]
 
   timeout     = local.lambda_default_timeout


### PR DESCRIPTION
This updates the registry to amazonlinux2. al1 will be deprecated in December.
