### PR TITLE
feat: use git clone filter and sparse checkout

### DIFF
--- a/api/async/publish.ts
+++ b/api/async/publish.ts
@@ -99,7 +99,7 @@ async function publishGithub(
 
   // Clone the repository from GitHub
   const cloneURL = `https://github.com/${repository}`;
-  const clonePath = await clone(cloneURL, ref);
+  const clonePath = await clone(cloneURL, ref, subdir);
 
   console.log("Finished clone");
 

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -1,4 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+import { join } from "../deps.ts";
 
 export async function clone(
   url: string,
@@ -29,7 +30,7 @@ export async function clone(
     throw new Error(`Failed to clone git repository ${url} at tag ${tag}`);
   }
 
-  const dir = `${subdir ?? ""}/*`;
+  const dir = subdir === undefined ? '/*' : join('/', subdir, '*');
   const checkout = Deno.run({
     cwd: tmp,
     cmd: ["git", "sparse-checkout", "set", dir],

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -1,17 +1,21 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 
-export async function clone(url: string, tag: string): Promise<string> {
+export async function clone(
+  url: string,
+  tag: string,
+  subdir?: string,
+): Promise<string> {
   const tmp = await Deno.makeTempDir();
   const clone = Deno.run({
     cmd: [
       "git",
       "clone",
-      "--depth",
-      "1",
+      "--depth=1",
+      "--filter=blob:none",
+      "--sparse",
       // TODO(lucacasonato): re enable, this is is to slow for the moment
       // "--recursive",
-      "-b",
-      tag,
+      `--branch=${tag}`,
       url,
       tmp,
     ],
@@ -23,6 +27,22 @@ export async function clone(url: string, tag: string): Promise<string> {
   clone.close();
   if (!cloneRes.success) {
     throw new Error(`Failed to clone git repository ${url} at tag ${tag}`);
+  }
+
+  const dir = `${subdir ?? ""}/*`;
+  const checkout = Deno.run({
+    cwd: tmp,
+    cmd: ["git", "sparse-checkout", "set", dir],
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  // TODO: better error handling
+  const checkoutRes = await checkout.status();
+  checkout.close();
+  if (!checkoutRes.success) {
+    throw new Error(
+      `Failed to sparse checkout ${dir} from git repository ${url} at tag ${tag}`,
+    );
   }
   return tmp;
 }

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -30,7 +30,7 @@ export async function clone(
     throw new Error(`Failed to clone git repository ${url} at tag ${tag}`);
   }
 
-  const dir = subdir === undefined ? '/*' : join('/', subdir, '*');
+  const dir = subdir === undefined ? "/*" : join("/", subdir, "*");
   const checkout = Deno.run({
     cwd: tmp,
     cmd: ["git", "sparse-checkout", "set", dir],


### PR DESCRIPTION
fixes #217

Previously, large git repositories could cause the Lambda /tmp to run out of space.  This PR introduces  a git clone filter which avoids fetching all blobs, and then does a sparse checkout of only the subdir (if specified).