### PR TITLE
Revert "feat: use git clone filter and sparse checkout (#223)"

### DIFF
--- a/api/async/publish.ts
+++ b/api/async/publish.ts
@@ -99,7 +99,7 @@ async function publishGithub(
 
   // Clone the repository from GitHub
   const cloneURL = `https://github.com/${repository}`;
-  const clonePath = await clone(cloneURL, ref, subdir);
+  const clonePath = await clone(cloneURL, ref);
 
   console.log("Finished clone");
 

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -1,22 +1,17 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-import { join } from "../deps.ts";
 
-export async function clone(
-  url: string,
-  tag: string,
-  subdir?: string,
-): Promise<string> {
+export async function clone(url: string, tag: string): Promise<string> {
   const tmp = await Deno.makeTempDir();
   const clone = Deno.run({
     cmd: [
       "git",
       "clone",
-      "--depth=1",
-      "--filter=blob:none",
-      "--sparse",
+      "--depth",
+      "1",
       // TODO(lucacasonato): re enable, this is is to slow for the moment
       // "--recursive",
-      `--branch=${tag}`,
+      "-b",
+      tag,
       url,
       tmp,
     ],
@@ -28,22 +23,6 @@ export async function clone(
   clone.close();
   if (!cloneRes.success) {
     throw new Error(`Failed to clone git repository ${url} at tag ${tag}`);
-  }
-
-  const dir = subdir === undefined ? "/*" : join("/", subdir, "*");
-  const checkout = Deno.run({
-    cwd: tmp,
-    cmd: ["git", "sparse-checkout", "set", dir],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  // TODO: better error handling
-  const checkoutRes = await checkout.status();
-  checkout.close();
-  if (!checkoutRes.success) {
-    throw new Error(
-      `Failed to sparse checkout ${dir} from git repository ${url} at tag ${tag}`,
-    );
   }
   return tmp;
 }


### PR DESCRIPTION
Looks like the version of Git installed on the Docker image is too old to have the `sparse` option. I'm reverting quickly and will look into fixing the issue for good tomorrow.

![Screenshot_2021-05-17 Registry - Grafana](https://user-images.githubusercontent.com/37561740/118562676-249aa480-b73b-11eb-9a2c-3edea85881fa.png)

This reverts commit ce7c35b3e10e69856f906c7a1a526600a0375b0d.