### PR TITLE
add up to date yum repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM hayd/deno-lambda:1.6.2
 
+RUN yum -y install https://packages.endpoint.com/rhel/7/main/x86_64/endpoint-repo-1.9-1.x86_64.rpm && \
+    sed -i 's/$releasever/7/' /etc/yum.repos.d/endpoint.repo
 RUN yum install git -y && rm -rf /var/cache/yum
 COPY deps.ts .
 RUN deno run --unstable -A deps.ts


### PR DESCRIPTION
Fixes the issue in bb44dbf by adding more up to date yum repos so that
we can install a version of git recent enough to support sparse
checkouts. With thanks to @christophgysin.