### PR TITLE
[RELAND 3] chore: update to Deno 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Deno environment
         uses: denolib/setup-deno@v2.3.0
         with:
-          deno-version: v1.6.2
+          deno-version: v1.17.3
 
       - uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM hayd/deno-lambda:1.6.2
+FROM hayd/deno-lambda:1.17.3
 
 RUN yum -y install https://packages.endpoint.com/rhel/7/main/x86_64/endpoint-repo-1.9-1.x86_64.rpm && \
     sed -i 's/$releasever/7/' /etc/yum.repos.d/endpoint.repo
 RUN yum install git -y && rm -rf /var/cache/yum
+
 COPY deps.ts .
-RUN deno run --unstable -A deps.ts
+RUN deno cache --unstable --no-check deps.ts
+
 COPY . .
-RUN deno cache --unstable $(find . -name "*.ts" -not -name "*_test.ts")
+RUN deno cache --unstable --no-check $(find . -name "*.ts" -not -name "*_test.ts")

--- a/api/async/cleanup.ts
+++ b/api/async/cleanup.ts
@@ -10,7 +10,7 @@
 import type { Context, ScheduledEvent } from "../../deps.ts";
 import { Database } from "../../utils/database.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 const INACTIVITY_PERIOD = 1000 * 60 * 60 * 24 * 30; // 30 days
 
 export async function handler(

--- a/api/async/cleanup_test.ts
+++ b/api/async/cleanup_test.ts
@@ -8,7 +8,7 @@ import { handler } from "./cleanup.ts";
 import { Database, Module } from "../../utils/database.ts";
 import { s3 } from "../../utils/storage.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 const ltest: Module = {
   name: "recent",
@@ -178,7 +178,7 @@ Deno.test({
       );
 
       const list = await database.listAllModules();
-      assert(list.length === 1);
+      assertEquals(list.length, 1);
       assertEquals(list[0].name, "old");
     } finally {
       await cleanupDatabase(database);

--- a/api/async/publish.ts
+++ b/api/async/publish.ts
@@ -9,7 +9,14 @@
  * the module name, GitHub repository, version, subdirectory ect.
  */
 
-import { Context, join, pooledMap, SQSEvent, walk } from "../../deps.ts";
+import {
+  Context,
+  join,
+  pooledMap,
+  readAll,
+  SQSEvent,
+  walk,
+} from "../../deps.ts";
 import { Build, BuildStats, Database } from "../../utils/database.ts";
 import { clone } from "../../utils/git.ts";
 import {
@@ -23,7 +30,7 @@ import type { DirectoryListingFile } from "../../utils/types.ts";
 import { DepGraph, runDenoInfo } from "../../utils/deno.ts";
 import { collectAsyncIterable, directorySize } from "../../utils/utils.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 const remoteURL = Deno.env.get("REMOTE_URL")!;
 
@@ -33,7 +40,7 @@ const decoder = new TextDecoder();
 
 export async function handler(
   event: SQSEvent,
-  context: Context,
+  _context: Context,
 ): Promise<void> {
   for (const record of event.Records) {
     const { buildID } = JSON.parse(record.body);
@@ -155,7 +162,7 @@ async function publishGithub(
     await collectAsyncIterable(pooledMap(65, directory, async (entry) => {
       if (entry.type === "file") {
         const file = await Deno.open(join(path, entry.path));
-        const body = await Deno.readAll(file);
+        const body = await readAll(file);
         await uploadVersionRaw(
           moduleName,
           version,
@@ -184,7 +191,7 @@ async function publishGithub(
       {
         uploaded_at: new Date().toISOString(),
         directory_listing: directory.sort((a, b) =>
-          a.path.localeCompare(b.path)
+          a.path.localeCompare(b.path, "en-US")
         ),
         upload_options: {
           type: "github",
@@ -262,10 +269,19 @@ export async function analyzeDependencies(build: Build): Promise<void> {
     }
 
     const graphToJoin = await runDenoInfo({ entrypoint, denoDir });
-    for (const url in graphToJoin) {
-      totalGraph[url] = {
-        ...graphToJoin[url],
-        deps: [...new Set(graphToJoin[url].deps)],
+    for (const dep of graphToJoin) {
+      if (dep.error || !dep.dependencies || !dep.size) {
+        throw new Error(`Failed to load ${dep.specifier}: ${dep.error}`);
+      }
+      const dependencies = dep.dependencies.map((d) => {
+        if (!d.code?.specifier) {
+          throw new Error(`Failed to load ${d.specifier}`);
+        }
+        return d.code.specifier;
+      });
+      totalGraph[dep.specifier] = {
+        size: dep.size,
+        deps: [...new Set(dependencies)],
       };
     }
   }

--- a/api/async/stargazers.ts
+++ b/api/async/stargazers.ts
@@ -31,7 +31,7 @@ const auth: GitHubAuth | undefined = secret
   : undefined;
 
 const gh = new GitHub(auth);
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 export async function handler(
   _: ScheduledEvent,

--- a/api/async/stargazers_test.ts
+++ b/api/async/stargazers_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-import { assert } from "../../test_deps.ts";
+import { assert, assertEquals } from "../../test_deps.ts";
 import {
   cleanupDatabase,
   createContext,
@@ -7,12 +7,9 @@ import {
 } from "../../utils/test_utils.ts";
 import { handler } from "./stargazers.ts";
 import { Database, Module } from "../../utils/database.ts";
-import { GitHub } from "../../utils/github.ts";
-import { assertEquals } from "https://deno.land/std@0.69.0/testing/asserts.ts";
 import { s3 } from "../../utils/storage.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
-const gh = new GitHub();
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 const ltest: Module = {
   name: "ltest",

--- a/api/builds/get.ts
+++ b/api/builds/get.ts
@@ -10,7 +10,7 @@ import type {
   APIGatewayProxyResultV2,
   Context,
 } from "../../deps.ts";
-import { ObjectId } from "../../deps.ts";
+import { Bson } from "../../deps.ts";
 import { respondJSON } from "../../utils/http.ts";
 import { Database } from "../../utils/database.ts";
 import type {
@@ -18,11 +18,11 @@ import type {
   APIErrorResponse,
 } from "../../utils/types.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 export async function handler(
   event: APIGatewayProxyEventV2,
-  context: Context,
+  _context: Context,
 ): Promise<APIGatewayProxyResultV2> {
   const id = event.pathParameters?.id;
 
@@ -36,8 +36,8 @@ export async function handler(
   }
 
   try {
-    ObjectId(id);
-  } catch (err) {
+    new Bson.ObjectId(id);
+  } catch (_err: unknown) {
     return respondJSON({
       statusCode: 400,
       body: JSON.stringify(

--- a/api/builds/get_test.ts
+++ b/api/builds/get_test.ts
@@ -9,10 +9,10 @@ import { assertEquals } from "../../test_deps.ts";
 import { Database } from "../../utils/database.ts";
 import { s3 } from "../../utils/storage.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 Deno.test({
-  name: "`/builds/:id`success",
+  name: "`/builds/:id` success",
   async fn() {
     try {
       const id = await database.createBuild({
@@ -56,7 +56,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "`/builds/:id` missing id",
+  name: "`/builds/:id` missing id",
   async fn() {
     assertEquals(
       await handler(
@@ -77,7 +77,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "`/builds/:id` invalid id",
+  name: "`/builds/:id` invalid id",
   async fn() {
     assertEquals(
       await handler(
@@ -100,7 +100,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "`/builds/:id` not found",
+  name: "`/builds/:id` not found",
   async fn() {
     assertEquals(
       await handler(

--- a/api/modules/get.ts
+++ b/api/modules/get.ts
@@ -18,11 +18,11 @@ import type {
   APIModuleGetResponse,
 } from "../../utils/types.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 export async function handler(
   event: APIGatewayProxyEventV2,
-  context: Context,
+  _context: Context,
 ): Promise<APIGatewayProxyResultV2> {
   const name = event.pathParameters?.name || undefined;
 

--- a/api/modules/get_test.ts
+++ b/api/modules/get_test.ts
@@ -8,7 +8,7 @@ import {
 import { assertEquals } from "../../test_deps.ts";
 import { Database } from "../../utils/database.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 Deno.test({
   name: "`/modules/:name` success",

--- a/api/modules/list.ts
+++ b/api/modules/list.ts
@@ -28,11 +28,11 @@ import type {
   APIModuleListShortResponse,
 } from "../../utils/types.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 export async function handler(
   event: APIGatewayProxyEventV2,
-  context: Context,
+  _context: Context,
 ): Promise<APIGatewayProxyResultV2> {
   const simple = event.queryStringParameters?.simple === "1";
   if (simple) {

--- a/api/modules/list_test.ts
+++ b/api/modules/list_test.ts
@@ -8,7 +8,7 @@ import {
 import { assert, assertEquals } from "../../test_deps.ts";
 import { Database } from "../../utils/database.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 Deno.test({
   name: "`/modules` success",

--- a/api/stats.ts
+++ b/api/stats.ts
@@ -14,11 +14,11 @@ import { respondJSON } from "../utils/http.ts";
 import { Database } from "../utils/database.ts";
 import type { APIStatsResponse } from "../utils/types.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 export async function handler(
-  event: APIGatewayProxyEventV2,
-  context: Context,
+  _event: APIGatewayProxyEventV2,
+  _context: Context,
 ): Promise<APIGatewayProxyResultV2> {
   const totalCount = await database.countModules();
   const totalVersions = await database.countAllVersions();

--- a/api/stats_test.ts
+++ b/api/stats_test.ts
@@ -8,7 +8,7 @@ import {
 import { assertEquals } from "../test_deps.ts";
 import { Database } from "../utils/database.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 Deno.test({
   name: "`/stats` success",

--- a/api/webhook/github.ts
+++ b/api/webhook/github.ts
@@ -43,12 +43,12 @@ interface WebhookEvent {
 
 const decoder = new TextDecoder();
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 // deno-lint-ignore require-await
 export async function handler(
   event: APIGatewayProxyEventV2,
-  context: Context,
+  _context: Context,
 ): Promise<APIGatewayProxyResultV2> {
   const ip = event.requestContext.http.sourceIp;
   if (!isGitHubHooksIP(ip)) {
@@ -72,7 +72,7 @@ export async function handler(
     });
   }
 
-  const headers = new Headers(event.headers);
+  const headers = new Headers(event.headers as Record<string, string>);
 
   if (
     !(headers.get("content-type") ?? "").startsWith("application/json") &&

--- a/api/webhook/github_create_test.ts
+++ b/api/webhook/github_create_test.ts
@@ -9,7 +9,8 @@ import {
 import { Database } from "../../utils/database.ts";
 import { assert, assertEquals } from "../../test_deps.ts";
 import { getMeta, s3, uploadMetaJson } from "../../utils/storage.ts";
-const database = new Database(Deno.env.get("MONGO_URI")!);
+
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 const decoder = new TextDecoder();
 
@@ -91,7 +92,7 @@ Deno.test({
       assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest-2"), null);
@@ -129,7 +130,7 @@ Deno.test({
       assertEquals(await getMeta("frisbee", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("frisbee"), null);
@@ -207,7 +208,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest5"), null);
 
       // Check that builds were queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -262,7 +263,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest17"), null);
 
       // Check that builds were queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Clean up
       await database._modules.deleteMany({});
@@ -277,7 +278,7 @@ Deno.test({
   name: "create event max registered to repository with dynamic owner quota",
   async fn() {
     try {
-      database.saveOwnerQuota({
+      await database.saveOwnerQuota({
         owner: "luca-rand",
         type: "github",
         max_modules: 7,
@@ -327,7 +328,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest9"), null);
 
       // Check that builds were queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -351,7 +352,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -374,7 +375,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -425,7 +426,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -448,7 +449,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -510,7 +511,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -549,7 +550,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -576,7 +577,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -599,7 +600,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -664,7 +665,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -691,7 +692,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -715,7 +716,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -766,7 +767,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -790,7 +791,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -841,7 +842,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -865,7 +866,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -954,7 +955,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -1049,7 +1050,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued in addition to the errored build
       assertEquals(builds.length, 2);
@@ -1087,7 +1088,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[1]._id.$oid
+            builds[1]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -1150,7 +1151,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -1173,7 +1174,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -1277,7 +1278,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -1409,7 +1410,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -1435,7 +1436,7 @@ Deno.test({
         {
           body:
             `{"success":true,"data":{"module":"ltest4","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-              builds[0]._id.$oid
+              builds[0]._id.toHexString()
             }"}}`,
           headers: {
             "content-type": "application/json",
@@ -1479,7 +1480,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -1502,7 +1503,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"frisbee","version":"0.0.7","repository":"luca-rand/frisbee","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",

--- a/api/webhook/github_ping_test.ts
+++ b/api/webhook/github_ping_test.ts
@@ -9,7 +9,7 @@ import {
 import { Database } from "../../utils/database.ts";
 import { assert, assertEquals } from "../../test_deps.ts";
 import { getMeta, s3 } from "../../utils/storage.ts";
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 const decoder = new TextDecoder();
 
@@ -53,7 +53,7 @@ Deno.test({
       assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest-2"), null);
@@ -91,7 +91,7 @@ Deno.test({
       assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest-2"), null);
@@ -129,7 +129,7 @@ Deno.test({
       assertEquals(await getMeta("frisbee", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("frisbee"), null);
@@ -189,7 +189,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -246,7 +246,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -321,7 +321,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest5"), null);
 
       // Check that builds were queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -383,7 +383,7 @@ Deno.test({
     try {
       const repoId = 123456789;
 
-      database.saveModule({
+      await database.saveModule({
         name: "ltest",
         description: "testing things",
         repo_id: repoId,
@@ -420,7 +420,7 @@ Deno.test({
       assertEquals(await getMeta("ltest", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       const ltest = await database.getModule("ltest");
       assert(ltest);
@@ -450,7 +450,7 @@ Deno.test({
   name: "ping event success capitalization",
   async fn() {
     try {
-      database.saveModule({
+      await database.saveModule({
         name: "ltest2",
         description: "testing things",
         repo_id: 274939732,
@@ -507,7 +507,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -519,7 +519,7 @@ Deno.test({
   name: "ping event blocked owner",
   async fn() {
     try {
-      database.saveOwnerQuota({
+      await database.saveOwnerQuota({
         type: "github",
         owner: "luca-rand",
         max_modules: 0,
@@ -550,7 +550,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -565,7 +565,7 @@ Deno.test({
   name: "ping event blocked sender",
   async fn() {
     try {
-      database.saveOwnerQuota({
+      await database.saveOwnerQuota({
         type: "github",
         owner: "lucacasonato",
         max_modules: 0,
@@ -596,7 +596,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);

--- a/api/webhook/github_push_test.ts
+++ b/api/webhook/github_push_test.ts
@@ -8,7 +8,7 @@ import {
 import { Database } from "../../utils/database.ts";
 import { assert, assertEquals } from "../../test_deps.ts";
 import { getMeta, s3, uploadMetaJson } from "../../utils/storage.ts";
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 const decoder = new TextDecoder();
 
@@ -87,7 +87,7 @@ Deno.test({
       assertEquals(await getMeta("ltest-2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest-2"), null);
@@ -125,7 +125,7 @@ Deno.test({
       assertEquals(await getMeta("frisbee", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("frisbee"), null);
@@ -203,7 +203,7 @@ Deno.test({
       assertEquals(await database.getModule("ltest5"), null);
 
       // Check that builds were queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -227,7 +227,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -250,7 +250,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -312,7 +312,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -351,7 +351,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -378,7 +378,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -401,7 +401,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -466,7 +466,7 @@ Deno.test({
       assertEquals(await getMeta("ltest2", "versions.json"), undefined);
 
       // Check that no builds are queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
 
       // Check that there is no module entry in the database
       assertEquals(await database.getModule("ltest2"), null);
@@ -493,7 +493,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -517,7 +517,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -568,7 +568,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -592,7 +592,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -643,7 +643,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -667,7 +667,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -756,7 +756,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -851,7 +851,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued in addition to the errored build
       assertEquals(builds.length, 2);
@@ -889,7 +889,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest2","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[1]._id.$oid
+            builds[1]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -952,7 +952,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -975,7 +975,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"ltest","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",
@@ -1058,7 +1058,7 @@ Deno.test({
       );
 
       // Check that no new build was queued
-      assertEquals(await database._builds.find({}), []);
+      assertEquals(await database._builds.find({}).toArray(), []);
     } finally {
       await cleanupDatabase(database);
       await s3.empty();
@@ -1190,7 +1190,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -1216,7 +1216,7 @@ Deno.test({
         {
           body:
             `{"success":true,"data":{"module":"ltest4","version":"0.0.7","repository":"luca-rand/testing","status_url":"https://deno.land/status/${
-              builds[0]._id.$oid
+              builds[0]._id.toHexString()
             }"}}`,
           headers: {
             "content-type": "application/json",
@@ -1260,7 +1260,7 @@ Deno.test({
         createContext(),
       );
 
-      const builds = await database._builds.find({});
+      const builds = await database._builds.find({}).toArray();
 
       // Check that a new build was queued
       assertEquals(builds.length, 1);
@@ -1283,7 +1283,7 @@ Deno.test({
       assertEquals(resp, {
         body:
           `{"success":true,"data":{"module":"frisbee","version":"0.0.7","repository":"luca-rand/frisbee","status_url":"https://deno.land/status/${
-            builds[0]._id.$oid
+            builds[0]._id.toHexString()
           }"}}`,
         headers: {
           "content-type": "application/json",

--- a/deps.ts
+++ b/deps.ts
@@ -10,11 +10,14 @@ export type {
   ScheduledEvent,
   SQSEvent,
 } from "https://deno.land/x/lambda@1.17.3/types.d.ts";
-export { Bson, MongoClient } from "https://deno.land/x/mongo@v0.29.0/mod.ts";
+export {
+  Bson,
+  MongoClient,
+} from "https://raw.githubusercontent.com/denodrivers/deno_mongo/09e4c50778786837f6054cff3f87c5836d3b7c65/mod.ts";
 export type {
   Collection as MongoCollection,
   Database as MongoDatabase,
-} from "https://deno.land/x/mongo@v0.29.0/mod.ts";
+} from "https://raw.githubusercontent.com/denodrivers/deno_mongo/09e4c50778786837f6054cff3f87c5836d3b7c65/mod.ts";
 export { S3Bucket } from "https://deno.land/x/s3@0.5.0/mod.ts";
 export { SQSQueue } from "https://deno.land/x/sqs@0.3.7/mod.ts";
 export { SSM } from "https://deno.land/x/ssm@0.1.4/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 
-export { expandGlob, walk } from "https://deno.land/std@0.74.0/fs/mod.ts";
-export { join } from "https://deno.land/std@0.74.0/path/mod.ts";
+export { expandGlob, walk } from "https://deno.land/std@0.121.0/fs/mod.ts";
+export { join } from "https://deno.land/std@0.121.0/path/mod.ts";
 export type {
   APIGatewayProxyEventV2,
   APIGatewayProxyResultV2,
@@ -9,14 +9,15 @@ export type {
   Context,
   ScheduledEvent,
   SQSEvent,
-} from "https://deno.land/x/lambda@1.4.6/types.d.ts";
-export {
-  MongoClient,
-  ObjectId,
-} from "https://deno.land/x/mongo@v0.13.0/mod.ts";
-export type { WithID } from "https://deno.land/x/mongo@v0.13.0/mod.ts";
-export { S3Bucket } from "https://deno.land/x/s3@0.2.0/mod.ts";
-export { SQSQueue } from "https://deno.land/x/sqs@0.3.4/mod.ts";
-export { SSM } from "https://deno.land/x/ssm@0.1.2/mod.ts";
-export { lookup } from "https://deno.land/x/media_types@v2.4.7/mod.ts";
-export { pooledMap } from "https://deno.land/std@0.74.0/async/mod.ts";
+} from "https://deno.land/x/lambda@1.17.3/types.d.ts";
+export { Bson, MongoClient } from "https://deno.land/x/mongo@v0.29.0/mod.ts";
+export type {
+  Collection as MongoCollection,
+  Database as MongoDatabase,
+} from "https://deno.land/x/mongo@v0.29.0/mod.ts";
+export { S3Bucket } from "https://deno.land/x/s3@0.5.0/mod.ts";
+export { SQSQueue } from "https://deno.land/x/sqs@0.3.7/mod.ts";
+export { SSM } from "https://deno.land/x/ssm@0.1.4/mod.ts";
+export { lookup } from "https://deno.land/x/media_types@v2.11.1/mod.ts";
+export { pooledMap } from "https://deno.land/std@0.121.0/async/mod.ts";
+export { readAll } from "https://deno.land/std@0.121.0/streams/conversion.ts";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,10 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: rootpassword
-    logging:
-      driver: none
   localstack:
     image: localstack/localstack:0.11.5
     network_mode: "host"
     environment:
       - "SERVICES=ssm"
+    logging:
+      driver: none

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,7 +7,7 @@ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 # required when using the aws cli v2 to disable the sticky pager
 # see https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-output-pager
 export AWS_PAGER=""
-export MONGO_URI=mongodb://root:rootpassword@localhost
+export MONGO_URI=mongodb://root:rootpassword@127.0.0.1:27017/?authMechanism=SCRAM-SHA-1
 export BUILD_QUEUE=http://localhost:9324/000000000000/builds
 export STORAGE_BUCKET=deno-registry2
 export MODERATION_BUCKET=deno-registry2-moderation
@@ -34,4 +34,4 @@ aws --endpoint-url=http://localhost:9324 sqs delete-queue --queue-url http://loc
 aws --endpoint-url=http://localhost:9324 sqs create-queue --queue-name builds --region us-east-1
 
 echo "Running tests..."
-deno test --unstable -A
+deno test --unstable -A $DENO_ARGS

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -4,8 +4,8 @@ export {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.74.0/testing/asserts.ts";
+} from "https://deno.land/std@0.121.0/testing/asserts.ts";
 export {
   bench,
   runBenchmarks,
-} from "https://deno.land/std@0.74.0/testing/bench.ts";
+} from "https://deno.land/std@0.121.0/testing/bench.ts";

--- a/utils/database_test.ts
+++ b/utils/database_test.ts
@@ -3,7 +3,7 @@
 import { assert, assertEquals } from "../test_deps.ts";
 import { Build, Database, Module, OwnerQuota } from "./database.ts";
 
-const database = new Database(Deno.env.get("MONGO_URI")!);
+const database = await Database.connect(Deno.env.get("MONGO_URI")!);
 
 await database._modules.deleteMany({});
 await database._builds.deleteMany({});

--- a/utils/deno.ts
+++ b/utils/deno.ts
@@ -10,9 +10,23 @@ export interface Dep {
   deps: string[];
 }
 
+export interface Module {
+  specifier: string;
+  error?: string;
+  size?: number;
+  dependencies?: ModuleDependency[];
+}
+
+export interface ModuleDependency {
+  specifier: string;
+  code?: {
+    specifier?: string;
+  };
+}
+
 export async function runDenoInfo(
   options: { entrypoint: string; denoDir: string },
-): Promise<DepGraph> {
+): Promise<Module[]> {
   const p = Deno.run({
     cmd: [
       "deno",
@@ -35,6 +49,6 @@ export async function runDenoInfo(
     throw new Error(`Failed to run deno info for ${options.entrypoint}`);
   }
   const text = decoder.decode(file);
-  const { files } = JSON.parse(text);
-  return files;
+  const { modules } = JSON.parse(text);
+  return modules;
 }

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -26,7 +26,7 @@ export function parseRequestBody(
     event.isBase64Encoded = false;
   }
 
-  const headers = new Headers(event.headers);
+  const headers = new Headers(event.headers as Record<string, string>);
   if (
     headers.get("content-type") === "application/x-www-form-urlencoded" &&
     event.body

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -32,7 +32,9 @@ export async function getMeta(
     join(module, "meta", file),
     {},
   );
-  return resp?.body;
+  if (resp === undefined) return undefined;
+  const data = await new Response(resp.body).arrayBuffer();
+  return new Uint8Array(data);
 }
 
 export async function getVersionMetaJson(
@@ -44,7 +46,9 @@ export async function getVersionMetaJson(
     join(module, "versions", version, "meta", file),
     {},
   );
-  return resp?.body;
+  if (resp === undefined) return undefined;
+  const data = await new Response(resp.body).arrayBuffer();
+  return new Uint8Array(data);
 }
 
 const encoder = new TextEncoder();
@@ -118,10 +122,12 @@ export async function uploadVersionMetaJson(
   return { etag: resp.etag };
 }
 
-export async function getForbiddenWords() {
+export async function getForbiddenWords(): Promise<Uint8Array> {
   const resp = await moderationS3.getObject(
     "badwords.txt",
     {},
   );
-  return resp?.body;
+  if (resp === undefined) throw new Error("badwords.txt not found");
+  const data = await new Response(resp.body).arrayBuffer();
+  return new Uint8Array(data);
 }


### PR DESCRIPTION
This is a reland of #274

This reland includes an additional fix that lets it correctly connect to MongoDB Atlas instances. See https://github.com/denodrivers/deno_mongo/pull/326

I have tested that the driver can now correctly connect to our database and serve requests. :fingers_crossed: this is actually the final reland.
